### PR TITLE
Material reception

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -56,6 +56,7 @@ $(document).on('turbolinks:load', function() {
 
   $('select.contact').select2({
     tags: true,
+    minimumResultsForSearch: Infinity,
     tokenSeparators: [',', ' ']
   });
 

--- a/app/assets/javascripts/barcode_reader.js
+++ b/app/assets/javascripts/barcode_reader.js
@@ -57,10 +57,6 @@
     }
   };
 
-  proto.displayeError = function(e, json) {
-    this.alert(json);
-  };
-
   proto.attachHandlers = function() {
     $(this.inputReader).on('keydown', $.proxy(this.readInput, this));
     $(this.form).on('ajax:success', $.proxy(this.onReceivedBarcode, this));

--- a/app/assets/javascripts/barcode_reader.js
+++ b/app/assets/javascripts/barcode_reader.js
@@ -1,14 +1,24 @@
 (function($, undefined) {
+  /**
+  * This component works with 3 elements:
+  * 1. An input to read a barcode with the following behaviour:
+  *     - On tabulator or carriage return will send the form (2)
+  * 2. A form that will obtain a data object about the barcode provided in the input:
+  *     - On success, it will trigger an event DataTableInitialization.addRow with some data inside an array
+  * 3. A table using DataTable js and DataTableInitialization class to manage the answer
+  **/
   function BarcodeReader(node, params) {
     this.node = $(node);
-    this.rows = params;
 
     this.form = $('form', this.node);
     this.table = $('table tbody', this.node);
+    this.containerTable = $('table', this.node);
     this.inputReader = $('input', this.node);
 
-    this.renderTable();
+    this.initTable(params);
     this.attachHandlers();
+
+    this.inputReader.focus();
   };
 
   var proto = BarcodeReader.prototype;
@@ -22,12 +32,12 @@
   };
 
   proto.addRow = function(rowInfo) {
-    this.table.append(['<tr><td>',rowInfo.labware.barcode,
-          '</td><td>', rowInfo.created_at, '</td></tr>'].join(''));
+    this.rows.push(rowInfo);
+    this.containerTable.trigger('DataTableInitialization.addRow', [[rowInfo.labware.barcode, rowInfo.created_at]]);
   };
 
-  proto.renderTable = function() {
-    this.table.html('');
+  proto.initTable = function(rows) {
+    this.rows = [];
     for (var i=0; i<this.rows.length; i++) {
       this.addRow(this.rows[i]);
     }
@@ -43,9 +53,12 @@
       this.alert(json.error);
     } else {
       $('.alert').toggleClass('invisible', true);
-      this.rows.push(json)
-      this.renderTable();
+      this.addRow(json);
     }
+  };
+
+  proto.displayeError = function(e, json) {
+    this.alert(json);
   };
 
   proto.attachHandlers = function() {

--- a/app/assets/javascripts/data_table_initialization.js
+++ b/app/assets/javascripts/data_table_initialization.js
@@ -1,0 +1,25 @@
+(function() {
+
+  function DataTableInitialization(node, params) {
+    this.node = $(node);
+    this.dataTable = $(node).DataTable(params);
+
+    this.attachHandlers();
+  };
+
+  var proto = DataTableInitialization.prototype;
+
+  proto.attachHandlers = function() {
+    this.node.on('DataTableInitialization.addRow', $.proxy(this.onAddRow, this));
+  };
+
+  proto.onAddRow = function(e, data) {
+    this.dataTable.row.add(data);
+    this.dataTable.draw();
+  };
+
+  $(document).ready(function() {
+    $(document).trigger('registerComponent.builder', {'DataTableInitialization': DataTableInitialization});
+  });
+
+}(jQuery));

--- a/app/assets/javascripts/loading_icon.js
+++ b/app/assets/javascripts/loading_icon.js
@@ -7,9 +7,9 @@
     this.containerIconClass = params.containerIconClass || "spinner";
     this.container = $('.'+this.containerIconClass, this.node);
 
-    this.iconClass = params.iconClass || "glyphicon";
+    this.iconClass = params.iconClass || "fa-refresh";
     this.icon = $('.'+this.iconClass, this.container);
-    this.loadingClass = params.loadingClass || "fast-right-spinner"
+    this.loadingClass = params.loadingClass || "fa-spin fa fa-refresh"
     this.hideNode = $(params.hideNodeSelector);
 
     $(this.container).hide();

--- a/app/assets/javascripts/loading_icon.js
+++ b/app/assets/javascripts/loading_icon.js
@@ -1,0 +1,56 @@
+(function($, undefined) {
+  function LoadingIcon(node, params) {
+    this.node=$(node);
+
+    this.listenForm = $(params.listenFormCssSelector);
+
+    this.containerIconClass = params.containerIconClass || "spinner";
+    this.container = $('.'+this.containerIconClass, this.node);
+
+    this.iconClass = params.iconClass || "glyphicon";
+    this.icon = $('.'+this.iconClass, this.container);
+    this.loadingClass = params.loadingClass || "fast-right-spinner"
+    this.hideNode = $(params.hideNodeSelector);
+
+    $(this.container).hide();
+
+    this.attachHandlers();
+  };
+  var proto = LoadingIcon.prototype;
+
+  proto.onStartLoad = function(e, data) {
+    if (data && data.node) {
+      $(data.node).hide();
+    }
+    if (this.hideNode) {
+      this.hideNode.hide();
+    }
+    $(this.icon).addClass(this.loadingClass);
+    $(this.container).show();
+  };
+
+  proto.onStopLoad = function(e, data) {
+    $(this.container).hide();
+    $(this.icon).removeClass(this.loadingClass);
+    if (data.node) {
+      $(data.node).show();
+    }
+    if (this.hideNode) {
+      this.hideNode.show();
+    }
+  };
+
+  proto.attachHandlers = function() {
+    $(this.node).on('load_start.loading_spinner', $.proxy(this.onStartLoad, this));
+    $(this.node).on('load_stop.loading_spinner', $.proxy(this.onStopLoad, this));
+
+    $(this.listenForm).on('submit.rails', $.proxy(this.onStartLoad, this));
+    $(this.listenForm).on('ajax:success', $.proxy(this.onStopLoad, this));
+    $(this.listenForm).on('ajax:error', $.proxy(this.onStopLoad, this));
+  };
+
+  $(document).ready(function() {
+    $(document).trigger('registerComponent.builder', {'LoadingIcon': LoadingIcon});
+  });
+
+}(jQuery));

--- a/app/assets/javascripts/single_table_manager.js
+++ b/app/assets/javascripts/single_table_manager.js
@@ -1,0 +1,235 @@
+(function($, undefined) {
+  function SingleTableManager(node, params) {
+    this.node = $(node);
+    this.params = params;
+
+    this.errorCells = {};
+    this.tooltipInputs = [];
+
+    this.form = $('form');
+    $(this.form).data('remote', true);
+    this.currentTab = $('a[data-toggle="tab"]')[0];
+
+    this.attachHandlers();
+  }
+
+  var proto = SingleTableManager.prototype;
+
+  proto.restoreTab = function(e) {
+    var currentTab = this.currentTab = $(e.target);
+    var data = this.dataForTab(currentTab);
+
+    this.cleanTooltips();
+
+    var barcode = $(e.target).attr('href').replace('#', '');
+    $('form td:first-child').html(barcode);
+    this.inputs().each($.proxy(this.restoreInput, this, data));
+
+    this.updateValidations();
+    //this.inputs().each($.proxy(this.updateErrorInput, this, data));
+  };
+
+  proto.updateErrorState = function(input, labwareId, wellId, fieldName) {
+    if (this.errorCells[labwareId] && this.errorCells[labwareId][wellId] &&
+      this.errorCells[labwareId][wellId][fieldName]) {
+      var msg = this.errorCells[labwareId][wellId][fieldName]
+      this.setErrorToInput(input, msg);
+    }
+  };
+
+  proto.setErrorToInput = function(input, msg) {
+    var tooltip = $(input).parent().tooltip({
+      title: msg,
+      container: 'body'
+    });
+    $(input).parent().tooltip('show');
+    $(input).parent().addClass('has-error');
+    this.tooltipInputs.push($(input).parent());
+  };
+
+  proto.cleanTooltips = function() {
+    for (var i=0; i<this.tooltipInputs.length; i++) {
+      $(this.tooltipInputs[i]).tooltip('hide');
+      setTimeout($.proxy(function() {
+        $(this.tooltipInputs[i]).tooltip('destroy');
+      }, this), 0);
+      $(this.tooltipInputs[i]).removeClass('has-error');
+
+    }
+    this.tooltipInputs=[];
+  };
+
+  proto.cellNameFromErrorKey = function(wellId, key) {
+    var fieldName = key.replace(/.*\./, '');
+    var name = [
+      "material_submission[labwares_attributes][0][wells_attributes][",
+      wellId, "][biomaterial_attributes][", fieldName,"]"].join('');
+    return(name);
+  };
+
+  proto.saveTab = function(e) {
+    var currentTab = $(e.target);
+    var data = this.dataForTab(currentTab);
+
+    this.inputs().each($.proxy(this.saveInput, this, data));
+
+    var input = $("<input name='material_submission[change_tab]' value='true' type='hidden' />");
+    $(this.form).append(input);
+
+    $.post($(this.form).attr('action'),  $(this.form).serialize()).then(
+      $.proxy(this.onReceive, this),
+      $.proxy(this.onError, this));
+    input.remove();
+  };
+
+  proto.onReceive = function(data, status) {
+    if (data.update_successful) {
+      this.errorCells = {};
+    } else {
+      for (var i=0; i<data.messages.length; i++) {
+        var message = data.messages[i];
+        this.resetCellNameErrors(message.labware_id);
+      }
+      for (var i=0; i<data.messages.length; i++) {
+        var message = data.messages[i];
+        var wellId = message.well_id;
+        this.storeCellNameError(message.labware_id, wellId, message.errors);
+      }
+    }
+    this.updateValidations();
+  };
+
+  proto.updateValidations = function() {
+    this.cleanTooltips();
+    this.inputs().each($.proxy(this.updateErrorInput, this, this.dataForTab(this.currentTab)));
+  };
+
+  proto.storeCellNameError = function(labwareId, wellId, errors) {
+    if (typeof this.errorCells[labwareId]==='undefined') {
+      this.resetCellNameErrors(labwareId);
+    }
+    if (typeof this.errorCells[labwareId][wellId]==='undefined') {
+      this.errorCells[labwareId][wellId]={};
+    }
+    for (var key in errors) {
+      var fieldName = key.replace(/.*\./, '');
+      this.errorCells[labwareId][wellId][fieldName]=errors[key];
+    }
+  };
+
+  proto.resetCellNameErrors = function(labwareId) {
+    this.errorCells[labwareId]={};
+  };
+
+  proto.inputs = function() {
+    return $('form input').filter(function(pos, input) {
+      return($(input).attr('name') && $(input).attr('name').search(/material_submission/)>=0);
+    });
+  };
+
+  proto.rowNumForName = function(name) {
+    var matching = name.match(/\[wells_attributes\]\[(\d*)\]/);
+    if (matching) {
+      return matching[1]
+    } else {
+      return null;
+    }
+  };
+
+  proto.fieldNameForName = function(name) {
+    var matching = name.match(/\[biomaterial_attributes\]\[(\w*)\]/);
+    if (matching) {
+      return matching[1];
+    } else {
+      return null;
+    }
+  };
+
+  proto.is_well_attribute_id = function(input) {
+    var name = $(input).attr('name');
+    return (name.search(/material_submission\[labwares_attributes\]\[0\]\[wells_attributes\]\[\d*\]\[id\]/) >=0);
+  };
+
+  proto.is_labware_id = function(input) {
+    var name = $(input).attr('name');
+    return (name.search(/material_submission\[labwares_attributes\]\[0\]\[id\]/) >= 0);
+  };
+
+  proto.saveInput = function(data, pos, input) {
+    var name = $(input).attr('name');
+    var rowNum = this.rowNumForName(name);
+    var fieldName = this.fieldNameForName(name);
+
+    if (data===null) {
+      return;
+    }
+
+    if ((rowNum!==null) && (fieldName!==null)) {
+      data.wells_attributes[rowNum].biomaterial_attributes[fieldName] = $(input).val();
+    }
+  };
+
+  proto.updateErrorInput = function(data, pos, input) {
+    var name = $(input).attr('name');
+    var rowNum = this.rowNumForName(name)
+    var fieldName = this.fieldNameForName(name)
+
+    if (fieldName) {
+      this.updateErrorState(input, data.id, data.wells_attributes[rowNum].id, fieldName);
+    }
+  };
+
+  proto.restoreInput = function(data, pos, input) {
+    var name = $(input).attr('name');
+    var rowNum = this.rowNumForName(name)
+    var fieldName = this.fieldNameForName(name)
+
+    if ((rowNum!==null) && (fieldName!==null)) {
+      $(input).val(data.wells_attributes[rowNum].biomaterial_attributes[fieldName]);
+    } else {
+      if (this.is_well_attribute_id(input)) {
+        $(input).val(data.wells_attributes[rowNum].id);
+      }
+      if (this.is_labware_id(input)) {
+        $(input).val(data.id);
+      }
+    }
+  };
+
+  proto.dataForTab = function(tab) {
+    for (var key in this.params) {
+      if ($(tab).attr('href') == ('#'+this.params[key].barcode.value)) {
+        return this.params[key];
+      }
+    }
+    return null;
+  };
+
+  proto.saveCurrentTab = function(e) {
+    this.saveTab({target: this.currentTab});
+    if (e) {
+      e.preventDefault();
+    }
+  };
+
+  proto.toDispatch = function(e) {
+    this.dispatchUrl = window.location.href.replace('provenance', 'dispatch');
+    window.location.href = this.dispatchUrl;
+  };
+
+  proto.attachHandlers = function() {
+    $('a[data-toggle="tab"]').on('hide.bs.tab', $.proxy(this.saveTab, this));
+    $('a[data-toggle="tab"]').on('show.bs.tab', $.proxy(this.restoreTab, this));
+    //$('table tbody tr td input').on('blur', $.proxy(this.saveCurrentTab, this));
+    $('form').on('submit.rails', $.proxy(this.saveTab, this));
+    $('button.save').on('click', $.proxy(this.saveCurrentTab, this));
+
+    $('input[type=submit]').on('click', $.proxy(this.toDispatch, this));
+  };
+
+  $(document).ready(function() {
+    $(document).trigger('registerComponent.builder', {'SingleTableManager': SingleTableManager});
+  });
+
+
+}(jQuery))

--- a/app/assets/javascripts/table_cursor_movement.js
+++ b/app/assets/javascripts/table_cursor_movement.js
@@ -1,0 +1,61 @@
+(function($,undefined) {
+  function TableCursorMovement(node, params) {
+    this.node = $(node);
+    this.params = params;
+
+    this.rowLength = $('tbody tr:first input:visible', this.node).length;
+    this.allInputs = $('tbody tr td input:visible', this.node);
+
+    this.attachHandlers();
+  }
+
+  var proto = TableCursorMovement.prototype;
+
+  proto.cursorBehaviour = function(e) {
+    if (!this.textSelected(e.target)) {
+      //return;
+    }
+    e = e || window.event;
+    var pos = this.allInputs.index(e.target);
+    if (e.keyCode == '38') { // up arrow
+      this.moveToInput(this.allInputs[Math.max(0, pos-this.rowLength)]);
+    }
+    else if (e.keyCode == '40') { // down arrow
+      this.moveToInput(this.allInputs[Math.min(this.allInputs.length, pos+this.rowLength)]);
+    }
+    else if (e.keyCode == '37') { // left arrow
+      if ((pos % this.rowLength) !== 0) {
+        this.moveToInput(this.allInputs[Math.max(0, pos-1)]);
+      }
+    }
+    else if (e.keyCode == '39') { // right arrow
+      if ((pos % this.rowLength) !== (this.rowLength-1)) {
+        this.moveToInput(this.allInputs[Math.min(this.allInputs.length, pos+1)]);
+      }
+    }
+  };
+
+  proto.moveToInput = function(input) {
+    input.focus();
+  };
+
+  proto.selectText = function(e) {
+    e.target.select();
+  };
+
+  proto.textSelected = function(text) {
+    return (text.selectionEnd>0);
+  };
+
+  proto.attachHandlers = function() {
+    $(this.allInputs).on('keydown', $.proxy(this.cursorBehaviour, this));
+    $(this.allInputs).on('focus', $.proxy(this.selectText, this));
+    $(this.allInputs).on('click', $.proxy(this.toggleSelectMode, this, false));
+  };
+
+  $(document).ready(function() {
+    $(document).trigger('registerComponent.builder', {'TableCursorMovement': TableCursorMovement});
+  });
+
+
+}(jQuery));

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,59 +30,20 @@ textarea.halvsies { height: 150px; width: 33% }
   float: none;
 }
 
-.spinner {
-  font-size: 20px;
+table thead th {cursor :s-resize;}
+table tbody tr {cursor :e-resize;}
+table tbody td {cursor :nw-resize;}
+
+table input.form-control {
+    background-color: transparent;
+    outline: none;
+    border: 0px;
+    border-color: inherit;
+    -webkit-box-shadow: none;
+    box-shadow: none;
 }
 
-.glyphicon.fast-right-spinner {
-    -webkit-animation: glyphicon-spin-r 1s infinite linear;
-    animation: glyphicon-spin-r 1s infinite linear;
+table input.form-control:focus {
+    border: 1px solid #ccc
 }
 
-@-webkit-keyframes glyphicon-spin-r {
-    0% {
-        -webkit-transform: rotate(0deg);
-        transform: rotate(0deg);
-    }
-
-    100% {
-        -webkit-transform: rotate(359deg);
-        transform: rotate(359deg);
-    }
-}
-
-@keyframes glyphicon-spin-r {
-    0% {
-        -webkit-transform: rotate(0deg);
-        transform: rotate(0deg);
-    }
-
-    100% {
-        -webkit-transform: rotate(359deg);
-        transform: rotate(359deg);
-    }
-}
-
-@-webkit-keyframes glyphicon-spin-l {
-    0% {
-        -webkit-transform: rotate(359deg);
-        transform: rotate(359deg);
-    }
-
-    100% {
-        -webkit-transform: rotate(0deg);
-        transform: rotate(0deg);
-    }
-}
-
-@keyframes glyphicon-spin-l {
-    0% {
-        -webkit-transform: rotate(359deg);
-        transform: rotate(359deg);
-    }
-
-    100% {
-        -webkit-transform: rotate(0deg);
-        transform: rotate(0deg);
-    }
-}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,3 +29,60 @@ textarea.halvsies { height: 150px; width: 33% }
   vertical-align: middle;
   float: none;
 }
+
+.spinner {
+  font-size: 20px;
+}
+
+.glyphicon.fast-right-spinner {
+    -webkit-animation: glyphicon-spin-r 1s infinite linear;
+    animation: glyphicon-spin-r 1s infinite linear;
+}
+
+@-webkit-keyframes glyphicon-spin-r {
+    0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+    }
+
+    100% {
+        -webkit-transform: rotate(359deg);
+        transform: rotate(359deg);
+    }
+}
+
+@keyframes glyphicon-spin-r {
+    0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+    }
+
+    100% {
+        -webkit-transform: rotate(359deg);
+        transform: rotate(359deg);
+    }
+}
+
+@-webkit-keyframes glyphicon-spin-l {
+    0% {
+        -webkit-transform: rotate(359deg);
+        transform: rotate(359deg);
+    }
+
+    100% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+    }
+}
+
+@keyframes glyphicon-spin-l {
+    0% {
+        -webkit-transform: rotate(359deg);
+        transform: rotate(359deg);
+    }
+
+    100% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+    }
+}

--- a/app/controllers/material_receptions_controller.rb
+++ b/app/controllers/material_receptions_controller.rb
@@ -6,7 +6,9 @@ class MaterialReceptionsController < ApplicationController
 
   def create
     @material_reception = MaterialReception.create(material_reception_params)
-    @material_reception.save
+    if @material_reception.save
+      ReceptionMailer.material_reception(@material_reception).deliver_later
+    end
     render json: @material_reception.presenter
   end
 

--- a/app/controllers/material_submissions_controller.rb
+++ b/app/controllers/material_submissions_controller.rb
@@ -26,4 +26,12 @@ class MaterialSubmissionsController < ApplicationController
     end
   end
 
+  def show
+    @material_submission = MaterialSubmission.find(params[:id])
+  end
+
+  def edit
+    @material_submission = MaterialSubmission.find(params[:id])
+  end
+
 end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -11,11 +11,17 @@ class SubmissionsController < ApplicationController
     params[:material_submission][:status] = step.to_s
     params[:material_submission][:status] = MaterialSubmission.ACTIVE if last_step?
 
-    if material_submission.update_attributes(material_submission_params) && last_step?
+    @status_success = material_submission.update_attributes(material_submission_params)
+    if @status_success && last_step?
       flash[:notice] = 'Your Submission has been created'
     end
-
-    render_wizard material_submission
+    if params[:material_submission][:status] == 'provenance'
+      unless @status_success
+        @invalid_data = material_submission.invalid_labwares.map(&:invalid_data).flatten.compact
+      end
+    else
+      render_wizard material_submission
+    end
   end
 
   protected

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -9,7 +9,7 @@ class SubmissionsController < ApplicationController
 
   def update
     params[:material_submission][:status] = step.to_s
-    params[:material_submission][:status] = 'active' if last_step?
+    params[:material_submission][:status] = MaterialSubmission.ACTIVE if last_step?
 
     if material_submission.update_attributes(material_submission_params) && last_step?
       flash[:notice] = 'Your Submission has been created'

--- a/app/helpers/material_submissions_helper.rb
+++ b/app/helpers/material_submissions_helper.rb
@@ -1,2 +1,27 @@
 module MaterialSubmissionsHelper
+def wells_attributes_for(plate)
+  plate.wells.each_with_index.reduce({}) do |memo, list|
+    well,index = list[0],list[1]
+    memo[index.to_s] = {
+      :id => well.id.to_s,
+      :position => well.position,
+      :biomaterial_attributes => (well.biomaterial || Biomaterial.new)
+    }
+    memo
+  end
+end
+
+def plate_attributes_for(labwares)
+  mlabware = {}
+  labwares.each_with_index do |plate, plate_idx|
+    mlabware[plate_idx.to_s] = {
+      :id => plate.id.to_s,
+      :barcode => plate.barcode,
+      :wells_attributes => wells_attributes_for(plate)
+    }
+  end
+  mlabware
+end
+
+
 end

--- a/app/helpers/submission_helper.rb
+++ b/app/helpers/submission_helper.rb
@@ -2,4 +2,9 @@ module SubmissionHelper
   def available_contacts_select_options
     [['None', '']].concat(Contact.all.map{|c| ["#{c.fullname} <#{c.email}>", c.email]})
   end
+
+  def available_labware_types_select_options
+    LabwareType.all.map{|c| ["#{c.name} (#{c.description})", c.id]}
+  end
+
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: "Aker <aker@aker>"
   layout 'mailer'
 end

--- a/app/mailers/reception_mailer.rb
+++ b/app/mailers/reception_mailer.rb
@@ -1,0 +1,12 @@
+class ReceptionMailer < ApplicationMailer
+
+
+  def material_reception(r)
+    @material_reception = r
+    @labware = @material_reception.labware
+    @material_submission = @labware.material_submission
+    @contact = @material_submission.contact
+    mail(to: @contact.email, subject: "Material received at #{@material_reception.created_at}")
+  end
+
+end

--- a/app/models/labware.rb
+++ b/app/models/labware.rb
@@ -22,4 +22,17 @@ class Labware < ApplicationRecord
     material_submission_labware.update_attributes(:state => 'received unclaimed')
   end
 
+  def invalid_data
+    if invalid?
+      wells.map{|w| w if w.invalid?}.compact.map do |invalid_well|
+        {
+          :labware_id => self.id,
+          :well_id => invalid_well.id,
+          :errors => invalid_well.errors.messages
+        }
+      end.flatten.compact
+    end
+  end
+
+
 end

--- a/app/models/labware.rb
+++ b/app/models/labware.rb
@@ -1,17 +1,25 @@
 class Labware < ApplicationRecord
   include Barcodeable
 
+  belongs_to :labware_type
   has_one :material_reception
 
-  has_one :material_submission_labware, as: :labware
+  has_one :material_submission_labware
   has_one :material_submission, through: :material_submission_labware
   has_many :wells, dependent: :destroy
-
-  belongs_to :labware_type
 
   delegate :size, :x_dimension_is_alpha, :y_dimension_is_alpha, :x_dimension_size, :y_dimension_size, to: :labware_type
 
   scope :with_barcode, ->(barcode) {
     joins(:barcode).where(:barcodes => {:value => barcode })
   }
+
+  def waiting_receipt
+    material_submission_labware.update_attributes(:state => 'awaiting receipt')
+  end
+
+  def received_unclaimed
+    material_submission_labware.update_attributes(:state => 'received unclaimed')
+  end
+
 end

--- a/app/models/labwares/tube.rb
+++ b/app/models/labwares/tube.rb
@@ -1,3 +1,4 @@
 class Tube < Labware
+  belongs_to :labware_type
   has_one :biomaterial, as: :containable
 end

--- a/app/models/material_reception.rb
+++ b/app/models/material_reception.rb
@@ -1,7 +1,13 @@
 class MaterialReception < ApplicationRecord
   belongs_to :labware
 
+  before_create :receive_labware
+
   validates :labware, uniqueness: { message: "cannot be received twice" }
+
+  def receive_labware
+    labware.received_unclaimed
+  end
 
   def barcode_value
     labware && labware.barcode && labware.barcode.value

--- a/app/models/material_submission.rb
+++ b/app/models/material_submission.rb
@@ -1,5 +1,8 @@
 class MaterialSubmission < ApplicationRecord
 
+  def self.ACTIVE
+    'active'
+  end
 
   belongs_to :labware_type, optional: true
   belongs_to :contact, optional: true
@@ -22,11 +25,11 @@ class MaterialSubmission < ApplicationRecord
 
   accepts_nested_attributes_for :labwares
 
-  scope :active, -> { where(status: 'active') }
-  scope :pending, -> { where.not(status: 'active') }
+  scope :active, -> { where(status: MaterialSubmission.ACTIVE) }
+  scope :pending, -> { where.not(status: MaterialSubmission.ACTIVE) }
 
   def active?
-    status == 'active'
+    status == MaterialSubmission.ACTIVE
   end
 
   def active_or_labware?
@@ -63,6 +66,9 @@ class MaterialSubmission < ApplicationRecord
   def contact_has_a_correct_email?
     if contact.email.empty?
       errors.add(:contact, "must have an email")
+    end
+    unless contact.email =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+      errors.add(:contact, "doest not have a valid email")
     end
   end
 

--- a/app/models/material_submission.rb
+++ b/app/models/material_submission.rb
@@ -51,6 +51,10 @@ class MaterialSubmission < ApplicationRecord
     super || 0
   end
 
+  def invalid_labwares
+    labwares.select(&:invalid?)
+  end
+
   private
 
   def set_labware
@@ -71,5 +75,6 @@ class MaterialSubmission < ApplicationRecord
       errors.add(:contact, "doest not have a valid email")
     end
   end
+
 
 end

--- a/app/models/material_submission_labware.rb
+++ b/app/models/material_submission_labware.rb
@@ -1,4 +1,11 @@
 class MaterialSubmissionLabware < ApplicationRecord
   belongs_to :material_submission
   belongs_to :labware
+
+  before_create :labware_to_wait_for_reception
+
+  def labware_to_wait_for_reception
+    self.state='awaiting receipt'
+  end
+
 end

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -3,7 +3,14 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>
-      /* Email styles need to be inline */
+      table.table {width: 100%; padding-left: 2em; padding-right: 3em;}
+      table.table thead tr { height: 40pt; text-align: center; vertical-align: middle; white-space: normal;}
+      table.table thead tr td{
+        padding-left:1em; padding-right: 1em; background: #f5f5f5;
+       font-weight: 700; font-family: Arial, sans-serif; text-align: center; vertical-align: middle;
+         white-space: normal; font-size: 10pt;}
+      table.table tbody tr td{  background-color: #f5f5f5; padding-left: 1em; padding-right: 1em; color: windowtext; text-align: center; font-weight: 400; font-style: normal; font-family: Arial; font-size: 10pt;}
+    </style>
     </style>
   </head>
 

--- a/app/views/material_receptions/_material_receptions.html.erb
+++ b/app/views/material_receptions/_material_receptions.html.erb
@@ -1,4 +1,6 @@
-<table class="table table-striped table-hover">
+<table class="table table-striped table-hover"
+  data-psd-component-class="DataTableInitialization"
+  data-psd-component-parameters="<%= { :order => [[1, 'desc']]}.to_json %>">
   <thead>
     <tr>
       <th>Barcode</th>

--- a/app/views/material_receptions/index.html.erb
+++ b/app/views/material_receptions/index.html.erb
@@ -30,7 +30,7 @@
 
   <div class="">
     <div class="col-md-12">
-      <h2>Received material  <span class="spinner"><span class="glyphicon glyphicon-refresh icon-login-refresh" /></span></h2>
+      <h2>Received material  <span class="spinner"><span class="fa fa-refresh" /></span></h2>
 
 
       <%= render "material_receptions", material_receptions: @material_receptions %>

--- a/app/views/material_receptions/index.html.erb
+++ b/app/views/material_receptions/index.html.erb
@@ -12,21 +12,31 @@
     <p class='alert-msg'>&nbsp;</p>
   </div>
 
-<div data-psd-component-class='BarcodeReader' data-psd-component-parameters="<%= @material_receptions.map(&:presenter).to_json %>">
+<div  data-psd-component-class="LoadingIcon" data-psd-component-parameters="<%= { listenFormCssSelector: 'form'}.to_json %>">
+<div class="row" data-psd-component-class='BarcodeReader' data-psd-component-parameters="<%= @material_receptions.map(&:presenter).to_json %>">
 <%= bootstrap_form_for(@material_reception, remote: true) do |f| %>
-  <div class='input-group row'>
-    <span class="input-group-addon glyphicon glyphicon-barcode" aria-hidden="true" style="top:0px;"></span>
-    <%= f.text_field :barcode_value, :placeholder => 'Scan a barcode', hide_label: true, autocomplete: 'off' %>
+  <div class="center-block">
+
+  <div class='input-group col-md-10 col-md-offset-1 col-xs-10 col-xs-offset-1'>
+    <span class="input-group-addon glyphicon glyphicon-barcode" aria-hidden="true" style="top:0px;padding-left:1em;"></span>
+    <%= f.text_field :barcode_value, :placeholder => 'Scan a barcode', hide_label: true, autocomplete: 'off', :style => 'padding-right:1em;' %>
+  </div>
+  </div>
+
+  <div>
+    &nbsp;
   </div>
 
 
-
-  <div class="row">
+  <div class="">
     <div class="col-md-12">
-      <h2>Received material</h2>
+      <h2>Received material  <span class="spinner"><span class="glyphicon glyphicon-refresh icon-login-refresh" /></span></h2>
+
+
       <%= render "material_receptions", material_receptions: @material_receptions %>
     </div>
   </div>
 <% end %>
+</div>
 </div>
 

--- a/app/views/material_receptions/new.html.erb
+++ b/app/views/material_receptions/new.html.erb
@@ -11,6 +11,8 @@
   <div class='input-group'>
     <span class="input-group-addon glyphicon glyphicon-barcode" aria-hidden="true" style="top:0px;"></span>
     <%= f.text_field :barcode_value, :placeholder => 'Scan a barcode', hide_label: true, autocomplete: 'off' %>
+    <span class="glyphicon glyphicon-refresh icon-login-refresh"
+      data-psd-component-class="LoadingIcon" data-psd-component-parameters="<%= { listenFormCssSelector: 'form'}.to_json %>"></div>
   </div>
 <% end %>
 

--- a/app/views/material_submissions/_form.html.erb
+++ b/app/views/material_submissions/_form.html.erb
@@ -1,0 +1,26 @@
+<%= bootstrap_form_for(material_submission) do |f| %>
+<div class="field">
+  <%= f.text_field :no_of_labwares_required, :readonly => readonly %>
+</div>
+
+<div class="field">
+  <%= f.text_field :supply_labwares, :readonly => readonly %>
+</div>
+
+<div class="field">
+  <%= f.select :labware_type, available_labware_types_select_options, {:selected => material_submission.labware_type_id}, {:disabled => readonly } %>
+</div>
+
+<div class="field">
+  <%= f.text_field :status, :readonly => readonly %>
+</div>
+
+<div class="field">
+  <%= f.text_area :address, style: 'resize: none; width: 100%; height: 10em;', :disabled => readonly %>
+</div>
+
+
+<div class="field">
+  <%= f.select :contact, available_contacts_select_options, {:selected => material_submission.contact_id}, {:disabled => readonly }%>
+</div>
+<% end %>

--- a/app/views/material_submissions/edit.html.erb
+++ b/app/views/material_submissions/edit.html.erb
@@ -1,0 +1,11 @@
+<% content_for :main_title do %>
+  Material Submission
+<% end %>
+<% content_for :title_button do %>
+  <%= link_to 'To Reception', material_receptions_path, class: 'btn btn-info vcenter', style: 'margin-top: 28px' %>
+
+<% end %>
+
+<%= render :partial => 'form', :locals => { :material_submission => @material_submission, :readonly => false} %>
+
+<%= link_to 'Back', :back, class: 'btn btn-primary' %>

--- a/app/views/material_submissions/show.html.erb
+++ b/app/views/material_submissions/show.html.erb
@@ -1,0 +1,11 @@
+<% content_for :main_title do %>
+  Material Submission
+<% end %>
+<% content_for :title_button do %>
+  <%= link_to 'To Reception', material_receptions_path, class: 'btn btn-info vcenter', style: 'margin-top: 28px' %>
+
+<% end %>
+
+<%= render :partial => 'form', :locals => { :material_submission => @material_submission, :readonly => true} %>
+
+<%= link_to 'Back', :back, class: 'btn btn-primary' %>

--- a/app/views/reception_mailer/material_reception.html.erb
+++ b/app/views/reception_mailer/material_reception.html.erb
@@ -1,0 +1,13 @@
+<p>Hi,</p>
+<p>We've just received the following material mailed to you:</p>
+
+<table class="table">
+  <thead>
+    <tr><td>Submission</td><td>Barcode</td><td>Type</td><td>Created at</td></tr>
+  </thead>
+  <tbody>
+    <tr><td><%= @material_submission.id %> </td><td> <%= @labware.barcode.value %> </td><td> <%= @labware.type %> </td><td> <%= @material_submission.created_at %> </td></tr>
+  </tbody>
+</table>
+
+</p>Regards</p>

--- a/app/views/submissions/_buttons.html.erb
+++ b/app/views/submissions/_buttons.html.erb
@@ -8,7 +8,11 @@
       <% if (last_step?) %>
         <%= f.submit "Save & Exit", class: "btn btn-primary", style: "float: right" %>
       <% else %>
-        <%= f.submit "Next", class: "btn btn-default", style: "float: right" %>
+        <% if step == :provenance %>
+          <%= link_to "Next", wizard_path(:dispatch), {class: "btn btn-default", style: "float: right" } %>
+        <% else %>
+          <%= f.submit "Next", class: "btn btn-default", style: "float: right" %>
+        <% end %>
       <% end %>
 
       <%= link_to 'Cancel', material_submission,

--- a/app/views/submissions/dispatch.html.erb
+++ b/app/views/submissions/dispatch.html.erb
@@ -9,7 +9,7 @@
 
 
 
-      <%= f.text_area :address, value: "Dr. Alan Kay\n\n80 Xerox Palo Alto Research Center\nA place\nUSA", control_class: 'form-control halvsies' %>
+      <%= f.text_area :address, value: "Dr. Alan Kay\n\n80 Xerox Palo Alto Research Center\nA place\nUSA", control_class: 'form-control halvsies', style: 'resize: none; width: 100%;' %>
 
 
 
@@ -22,7 +22,8 @@
     <p>The following contact will be noticed when the materials arrive at Sanger Institute:</p>
 
     <%= f.fields_for(:contact_attributes) do |c| %>
-      <%= c.select(:email, options_for_select(available_contacts_select_options), {}, {class: "form-control contact"}) %>
+      <% selection = material_submission.contact ? {:selected => material_submission.contact.email} : {} %>
+      <%= c.select(:email, options_for_select(available_contacts_select_options), selection, {class: "form-control contact"}) %>
     <% end %>
 
   </div>

--- a/app/views/submissions/provenance.html.erb
+++ b/app/views/submissions/provenance.html.erb
@@ -6,7 +6,7 @@
 
   <ul class="nav nav-tabs" role="tablist">
 
-    <% material_submission.labwares.each_with_index do |labware, i| %>
+    <% material_submission.labwares.includes(:barcode).each_with_index do |labware, i| %>
       <li class="<%= 'active' if i == 0 %>" role="presentation">
         <a data-toggle="tab" href="#<%= labware.barcode.value %>" aria-controls="<%= labware.barcode.value %>" role="tab">
           <%= labware.barcode.value %>
@@ -18,7 +18,7 @@
 
   <div class="tab-content">
 
-    <%= f.fields_for :labwares, material_submission.labwares do |labware_fields| %>
+    <%= f.fields_for :labwares, material_submission.labwares.includes(:biomaterials, :barcode) do |labware_fields| %>
 
         <div role="tabpanel" class="tab-pane <%= 'active' if labware_fields.index == 0 %>" id="<%= labware_fields.object.barcode.value %>">
 

--- a/app/views/submissions/provenance.html.erb
+++ b/app/views/submissions/provenance.html.erb
@@ -1,6 +1,8 @@
 <%= render partial: 'submission_header', locals: { title: "Step 2: Biomaterial Provenance" , progress: 50 } %>
 
-<%= bootstrap_form_for material_submission, url: wizard_path, method: :put do |f| %>
+<div data-psd-component-class="SingleTableManager"
+  data-psd-component-parameters="<%= plate_attributes_for(material_submission.labwares.includes(:biomaterials, :barcode)).to_json %>">
+<%= bootstrap_form_for material_submission, remote: true, url: wizard_path, method: :put, :html => {:'data-type' => 'json'} do |f| %>
 
   <%= render 'buttons', material_submission: material_submission, f: f %>
 
@@ -16,9 +18,12 @@
 
   </ul>
 
+
+
   <div class="tab-content">
 
-    <%= f.fields_for :labwares, material_submission.labwares.includes(:biomaterials, :barcode) do |labware_fields| %>
+
+    <%= f.fields_for :labwares, [material_submission.labwares.includes(:biomaterials, :barcode).first] do |labware_fields| %>
 
         <div role="tabpanel" class="tab-pane <%= 'active' if labware_fields.index == 0 %>" id="<%= labware_fields.object.barcode.value %>">
 
@@ -36,7 +41,10 @@
           </div>
 
 
-          <table data-behavior="datatable" class="table table-condensed table-striped">
+          <table data-behavior="datatable" class="table table-condensed table-striped"
+          <%# data-psd-component-class="TableCursorMovement" data-psd-component-parameters="{}" %>
+          >
+            <button class="btn btn-default save"><span class="glyphicon glyphicon-floppy-save"></span></button>
             <thead>
               <tr>
                 <th>Plate Barcode</th>
@@ -50,8 +58,7 @@
             </thead>
 
             <tbody>
-
-            <%= labware_fields.fields_for :wells, labware_fields.object.wells do |well_fields| %>
+            <%= labware_fields.fields_for :wells, labware_fields.object.wells.includes(:biomaterial) do |well_fields| %>
 
               <tr>
                 <td><%= labware_fields.object.barcode.value %></td>
@@ -86,3 +93,4 @@
   <%= render 'buttons', material_submission: material_submission, f: f %>
 
 <% end %>
+</div>

--- a/app/views/submissions/update.json.erb
+++ b/app/views/submissions/update.json.erb
@@ -1,0 +1,1 @@
+<%= {:update_successful => @status_success, :messages => @invalid_data}.to_json.html_safe %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.action_mailer.delivery_method = :sendmail
 end

--- a/db/migrate/20161020084010_add_state_to_material_submissions_labware.rb
+++ b/db/migrate/20161020084010_add_state_to_material_submissions_labware.rb
@@ -1,0 +1,5 @@
+class AddStateToMaterialSubmissionsLabware < ActiveRecord::Migration[5.0]
+  def change
+    add_column :material_submission_labwares, :state, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161012135533) do
+ActiveRecord::Schema.define(version: 20161020084010) do
 
   create_table "barcodes", force: :cascade do |t|
     t.string   "barcode_type"
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 20161012135533) do
     t.integer  "labware_id"
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
+    t.text     "state"
     t.index ["labware_id"], name: "index_material_submission_labwares_on_labware_id"
     t.index ["material_submission_id"], name: "index_material_submission_labwares_on_material_submission_id"
   end

--- a/spec/controllers/material_receptions_controller_spec.rb
+++ b/spec/controllers/material_receptions_controller_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe MaterialReceptionsController, type: :controller do
   describe "When scanning a barcode" do
     setup do
       @labware = FactoryGirl.create(:labware)
+      @submission = FactoryGirl.create(:material_submission)
+      @submission.labwares << @labware
     end
 
     it "does not add the barcode to the list if the barcode does not exist" do

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -19,7 +19,7 @@ def step_params(material_submission, step_name)
         {
           :status => 'active',
           :address => 'Testing address',
-          :contact_attributes => { :email => 'Contact test email'}
+          :contact_attributes => { :email => 'correct@email.ac.uk'}
         }
       when :dispatch_contact_error
         step_name = :dispatch

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -12,6 +12,7 @@ def step_params(material_submission, step_name)
         }
       when :provenance
         {
+
               :status => 'provenance',
               :labwares_attributes => plate_attributes_for(material_submission.labwares)
         }
@@ -31,6 +32,7 @@ def step_params(material_submission, step_name)
       end
     }.merge(
       {
+        :format => (step_name == :provenance) ? 'json' : 'html',
         :material_submission_id => material_submission.id,
         :id => step_name
       }


### PR DESCRIPTION
- Removed text input in select for finding a contact
- DataTable initialisation by html data parameters
- Loading image to notice the user that a query has been sent to the server on labware reception
- Component SingleTableManager to be able to work with several tables using the same html table
- Post to update the plate data on the following situations: 
  - Tab change
  - Next step
  - Save button
  - Tooltips displaying the server error when updating the plate
- Component TableCursorMovement with a initial implementation of traversing the form table with the cursor keys in a spreadsheet way
- CSS styles to create animation of the Loading image on Labware reception
- Mail sent to the contact address by using ActiveJob. We will need to provide an ActiveJob compatible solution (like delayed job), but for
  now it can work in this way for prototyping purposes
- Attributes json generation for SingleTableManager in a helper file
- Added status 'awaiting receipt' and 'received unclaimed' to Asset. 
- Creation of a JSON with the server side validation errors found when saving a new plate, in order to provide the user with this messages by tooltips.
