### PR TITLE
a36 - post to material_submissions/claim to claim submissions

### DIFF
--- a/app/models/material_submission.rb
+++ b/app/models/material_submission.rb
@@ -8,6 +8,10 @@ class MaterialSubmission < ApplicationRecord
     'awaiting receipt'
   end
 
+  def self.CLAIMED
+    'claimed'
+  end
+
   belongs_to :labware_type, optional: true
   belongs_to :contact, optional: true
   accepts_nested_attributes_for :contact, update_only: true
@@ -31,7 +35,7 @@ class MaterialSubmission < ApplicationRecord
 
   scope :active, -> { where(status: MaterialSubmission.ACTIVE) }
   scope :awaiting, -> { where(status: MaterialSubmission.AWAITING) }
-  scope :pending, -> { where.not(status: [MaterialSubmission.ACTIVE, MaterialSubmission.AWAITING]) }
+  scope :pending, -> { where.not(status: [MaterialSubmission.ACTIVE, MaterialSubmission.AWAITING, MaterialSubmission.CLAIMED]) }
 
   def active?
     status == MaterialSubmission.ACTIVE

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,5 @@ Rails.application.routes.draw do
 
   resources :completed_submissions
   post '/completed_submissions/print', to: 'completed_submissions#print'
+  post '/material_submissions/claim', to: 'submissions#claim'
 end


### PR DESCRIPTION
Multiple submissions can be claimed.
The submission ids and the collection id must be passed as post data.
The biomaterial ids and colletion id are sent via the SetMaterial
class to the set service.
The claim has its status set to 'claimed'.