### PR TITLE
Stamp id will be send on claim

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem 'zipkin-tracer'
 gem 'aker-set-client', github: 'sanger/aker-set-client'
 gem 'aker-study-client', github: 'sanger/aker-study-client'
 gem 'matcon_client', github: 'sanger/aker-matcon-client'
+gem 'aker_stamp_client', github: 'harrietc52/aker-stamp-client'
 #gem 'material_service_client', '~> 1.0.1', github: 'sanger/material_service_client_gem'
 
 gem 'bootstrap-table-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,10 @@
 GIT
+  remote: git://github.com/harrietc52/aker-stamp-client.git
+  revision: 11a68d80c23e6df6d1a008c7473f7bed8f2ad9cb
+  specs:
+    aker_stamp_client (0.1.0)
+
+GIT
   remote: git://github.com/rails/activeresource.git
   revision: 029e282f13c9d7230470708c1046abbf65ce5dae
   branch: master
@@ -10,9 +16,9 @@ GIT
 
 GIT
   remote: git://github.com/sanger/aker-authentication.git
-  revision: 10b168e0bddecbcdcd2baf3bc460fb7bfd855e4e
+  revision: 09c11204f386071fb194d97bcbf36abd248378f2
   specs:
-    aker_authentication_gem (0.1.2)
+    aker_authentication_gem (0.1.3)
       activemodel
       devise
       devise_ldap_authenticatable
@@ -40,9 +46,9 @@ GIT
 
 GIT
   remote: git://github.com/sanger/aker-permission.git
-  revision: 184fbc371bddb467859e71ae3a0f06ba483eab9b
+  revision: 51eb6543489bd163415c39910fb56c45b1966c31
   specs:
-    aker_permission_gem (0.1.1)
+    aker_permission_gem (0.4.0)
       cancancan
 
 GIT
@@ -240,7 +246,7 @@ GEM
       activesupport (>= 4.2.0)
     gmetric (0.1.3)
     hashdiff (0.3.4)
-    i18n (0.8.4)
+    i18n (0.8.6)
     ice_nine (0.11.2)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
@@ -270,7 +276,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.2.0)
-    minitest (5.10.2)
+    minitest (5.10.3)
     multi_json (1.12.1)
     multi_test (0.1.2)
     multipart-post (2.0.0)
@@ -459,6 +465,7 @@ DEPENDENCIES
   aker_authentication_gem!
   aker_credentials_gem!
   aker_permission_gem!
+  aker_stamp_client!
   bootstrap-sass (~> 3.3.6)
   bootstrap-table-rails
   bootstrap_form
@@ -508,4 +515,4 @@ DEPENDENCIES
   zipkin-tracer
 
 BUNDLED WITH
-   1.14.6
+   1.15.2

--- a/app/assets/javascripts/aker.js
+++ b/app/assets/javascripts/aker.js
@@ -1,12 +1,13 @@
 (function(self) {
   self.Aker = self.Aker || {};
 
-  self.Aker.claim = function(submissionIds, collectionId) {
+  self.Aker.claim = function(submissionIds, collectionId, stampId) {
     $.post({
       url: '/claim_submissions/claim',
       data: {
         submission_ids: submissionIds,
-        collection_id: collectionId
+        collection_id: collectionId,
+        stamp_id: stampId
       },
       success: function() {
         window.location.reload(true);

--- a/app/assets/javascripts/claimed_sets.js
+++ b/app/assets/javascripts/claimed_sets.js
@@ -17,14 +17,15 @@
     $('.table tbody tr', $(NODE)).each(function(pos, node) {
       var list = $('td', node);
       var collectionId = data[pos].uuid;
+
       var claimingButton = $('<button class="btn btn-default">Claim</button>');
 
       claimingButton.on('click', function(e) {
         var submissionIds = $($('table', $(SUBMISSIONS_NODE))).bootstrapTable('getAllSelections').map(function(node, pos) {
           return node.id;
         });
-
-        Aker.claim(submissionIds, collectionId);
+        var stampId = $('#stamp_id').val()
+        Aker.claim(submissionIds, collectionId, stampId);
       });
 
       $(list[list.length - 1]).html(claimingButton);

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,4 +5,10 @@ class ApplicationController < ActionController::Base
   include AkerAuthenticationGem::AuthController
   include JWTCredentials
 
+
+  rescue_from AkerPermissionGem::NotAuthorized do |e|
+    respond_to do |format|
+      format.html { redirect_to root_path, alert: e.message }
+    end
+  end
 end

--- a/app/controllers/claim_submissions_controller.rb
+++ b/app/controllers/claim_submissions_controller.rb
@@ -1,6 +1,8 @@
 class ClaimSubmissionsController < ApplicationController
 
   def index
+    @stamps = StampClient::Stamp.all
+
     @email = current_user.email
     @contact = Contact.find_by_email(@email)
     if @contact.nil?
@@ -19,6 +21,7 @@ class ClaimSubmissionsController < ApplicationController
     cp = claim_params
     sub_ids = cp[:submission_ids]
     col_id = cp[:collection_id]
+    stamp_id = cp[:stamp_id]
     submissions = MaterialSubmission.where(id: sub_ids)
     not_ready = submissions.reject(&:ready_for_claim?).map { |s| "Submission #{s.id}" }
     unless not_ready.empty?
@@ -26,8 +29,18 @@ class ClaimSubmissionsController < ApplicationController
       return
     end
     material_ids = submissions_material_ids(submissions)
-    SetClient::Set.find(col_id).first.set_materials(material_ids)
+    
+    begin
+      stamp = StampClient::Stamp.find(stamp_id).first
+      stamp.apply_to(material_ids)    
+    rescue JsonApiClient::Errors::AccessDenied
+      raise AkerPermissionGem::NotAuthorized.new('You cannot set a stamp of permissions to the materials because you do not have the ownership of the materials you want to claim')
+    end
+
+    SetClient::Set.find(col_id).first.set_materials(material_ids)    
+
     material_ids.each { |mid| MatconClient::Material.new(_id: mid).update_attributes(available: true) }
+
     submissions.each(&:claim_claimable_labwares)
   end
 
@@ -37,6 +50,7 @@ class ClaimSubmissionsController < ApplicationController
     {
       submission_ids: params.require(:submission_ids),
       collection_id: params.require(:collection_id),
+      stamp_id: params.require(:stamp_id)
     }
   end
 

--- a/app/services/dispatch_steps/create_materials_step.rb
+++ b/app/services/dispatch_steps/create_materials_step.rb
@@ -12,7 +12,7 @@ class CreateMaterialsStep
       contents = labware.contents
       contents.each do | address, bio_data |
         unless bio_data['id']
-          m = MatconClient::Material.create(bio_data)
+          m = MatconClient::Material.create(bio_data.merge(owner_id: @material_submission.contact.email))
           bio_data['id'] = m.id
           changed = true
         end

--- a/app/views/claim_submissions/index.html.erb
+++ b/app/views/claim_submissions/index.html.erb
@@ -4,8 +4,19 @@
 <%= render :partial => 'title_buttons' %>
 
 <div class="container">
-  <div class="claiming-display row">
-
+  <div class="stamping-display row">
+    <div class="h5"><span class="index">1.</span> Select a stamp of permissions to apply:</div> 
+    <select class="form-control" id="stamp_id">
+      <%= @stamps.each do |stamp| %>
+        <option value="<%= stamp.id %>">Stamp '<%= stamp.name %>' from '<%= stamp.owner_id %>'</option>
+      <% end %>
+    </select>
+  </div>
+  <div class="row">
+    &nbsp;
+  </div>
+  <div class="claiming-display row disabled">
+    <div class="h5"><span class="index">2.</span> Select a set from the table and claim it inside a collection by clicking on 'Claim':</div>
     <div class="col-md-4">
 
       <div class="row rowspace">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,6 +68,8 @@ Rails.application.configure do
   config.ownership_url = 'http://localhost:4000/ownerships'
   config.ownership_url_default_proxy = 'http://localhost:4000'
 
+  config.stamp_url = 'http://localhost:7000/api/v1/'
+
   config.pmb_uri = ENV.fetch('PMB_URI','http://localhost:10000/v1')
 
   config.ehmdmc_url = 'http://localhost:3501/validate'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,6 +46,7 @@ Rails.application.configure do
   config.ownership_url = 'http://localhost:4000/ownerships'
   config.ownership_url_default_proxy = 'http://localhost:4000'
   config.pmb_uri = ENV.fetch('PMB_URI','http://localhost:10000/v1')
+  config.stamp_url = 'http://localhost:7000/api/v1/'
   config.study_url = 'http://localhost:3300/api/v1/'
 
   config.ehmdmc_url = 'http://localhost:3501/validate'

--- a/config/initializers/stamp_client.rb
+++ b/config/initializers/stamp_client.rb
@@ -1,0 +1,15 @@
+Rails.application.config.after_initialize do
+
+  StampClient::Base.site = Rails.application.config.stamp_url
+
+  StampClient::Base.connection do |connection|
+    ENV['HTTP_PROXY'] = nil
+    ENV['http_proxy'] = nil
+    ENV['https_proxy'] = nil
+    connection.faraday.proxy ''
+    connection.use JWTSerializer
+    if Rails.env.production? || Rails.env.staging?
+      connection.use ZipkinTracer::FaradayHandler, 'Stamp service'
+    end
+  end
+end

--- a/features/create_submission.feature
+++ b/features/create_submission.feature
@@ -30,8 +30,12 @@ Given I upload the file "test/data/manifest.csv"
 Then I should display the data of my file
 When I go to next screen
 Then I should not see any validation errors
+And I am in "Ethics"
 
-And I am in "Delivery Details"
+When I check "I confirm that no HMDMC is required"
+And I click on "Next"
+
+Then I am in "Delivery Details"
 
 Given I enter my details as collaborator
 And I select the contact "test@test"

--- a/features/step_definitions/basic_definitions.rb
+++ b/features/step_definitions/basic_definitions.rb
@@ -30,6 +30,10 @@ Given(/^I click on "([^"]*)"$/) do |arg1|
   click_on(arg1)
 end
 
+Given(/^I check "([^"]*)"$/) do |arg1|
+  check(arg1)
+end
+
 Given(/^I go to next screen$/) do
   first('a.save').trigger('click')
 end
@@ -65,7 +69,11 @@ Then(/^I should not see any validation errors$/) do
 end
 
 When(/^I enter my details as collaborator$/) do
-  fill_in('Collaborator email', :with => 'test@test')
+  fill_in('Address', :with => 'Some address')
+end
+
+Then(/^show me the page$/) do
+  save_and_open_page
 end
 
 When(/^I select the contact "([^"]*)"$/) do |arg1|

--- a/spec/models/material_submission_spec.rb
+++ b/spec/models/material_submission_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'time'
 
 RSpec.describe MaterialSubmission, type: :model do
 
@@ -358,7 +359,7 @@ RSpec.describe MaterialSubmission, type: :model do
       lws = @submission.labwares
       lws.each { |lw| lw.update_attributes(print_count: 1) }
       lws[0...3].each { |lw| create(:material_reception, labware_id: lw.id)}
-      @old_claim_time = 1.day.ago
+      @old_claim_time = Time.strptime("2000-10-31", "%Y-%m-%d")
       lws[2].update_attributes(claimed: @old_claim_time)
 
       @submission.claim_claimable_labwares

--- a/spec/models/material_submission_spec.rb
+++ b/spec/models/material_submission_spec.rb
@@ -370,6 +370,7 @@ RSpec.describe MaterialSubmission, type: :model do
     end
 
     it "does not claim already claimed labware" do
+      @submission.labwares[2].reload
       expect(@submission.labwares[2].claimed).to eq(@old_claim_time)
     end
 

--- a/spec/services/dispatch_steps/create_materials_step_spec.rb
+++ b/spec/services/dispatch_steps/create_materials_step_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe :create_materials_step do
 
   def make_submission(labware_bio_ids)
     labwares = labware_bio_ids.map { |bio_ids| make_labware(bio_ids) }
-    @submission = double(:material_submission, labwares: labwares)
+    contact = double('contact', email: 'testing@email')
+    @submission = double(:material_submission, labwares: labwares, contact: contact)
   end
 
   def make_step(labware_bio_ids)

--- a/test/data/manifest.csv
+++ b/test/data/manifest.csv
@@ -1,4 +1,4 @@
-Well Position,supplier_name,donor_id,gender,common_name,phenotype
+Well Position,supplier_name,donor_id,gender,scientific_name,phenotype
 A:1,334455,3,male,Homo Sapiens,6
 A:2,334456,3,male,Homo Sapiens,6
 A:3,334457,3,female,Homo Sapiens,6


### PR DESCRIPTION
Error display when user is not authorized because is not the owner of the
materials he/she wants to change the permissions by applying a stamp
Display of the list of stamps available to apply on claiming
On material creation, the owner for the materials created is set to the contact,
instead of 'guest'
Testing csv file header change from common name to scientific name
New stamp service url configuration