### PR TITLE
When the owner is set no more updates are allowed for the set we are …

### DIFF
--- a/app/services/dispatch_steps/create_sets_step.rb
+++ b/app/services/dispatch_steps/create_sets_step.rb
@@ -6,7 +6,7 @@ class CreateSetsStep
   # If you're trying to be safe, you need to make sure errors from this method are caught.
   def up
     unless @material_submission.set_id
-      set = SetClient::Set.create(name: "Submission #{@material_submission.id}", owner_id: @material_submission.contact.email)
+      set = SetClient::Set.create(name: "Submission #{@material_submission.id}")
       @material_submission.update_attributes(set_id: set.id)
 
       # Adding materials to set
@@ -14,7 +14,11 @@ class CreateSetsStep
       uuids = @material_submission.labwares.flat_map { |lw| lw.contents.values }.flat_map { |c| c['id'] }
 
       set.set_materials(uuids)
-      set.update_attributes(locked: true)
+
+      # IMPORTANT!!
+      # A Set cannot be updated or removed anymore if you are not the owner of it, so 
+      # after giving an owner to the set, I won't be able to destroy it
+      set.update_attributes(locked: true, owner_id: @material_submission.contact.email)
     end
   end
 

--- a/spec/services/dispatch_steps/create_sets_step_spec.rb
+++ b/spec/services/dispatch_steps/create_sets_step_spec.rb
@@ -55,8 +55,7 @@ RSpec.describe :create_sets_step do
 
       it "should create a set" do
         expect(SetClient::Set).to have_received(:create).with(
-          name: "Submission #{@submission.id}",
-          owner_id: @submission.contact.email,
+          name: "Submission #{@submission.id}"
         )
         expect(@sets.length).to eq 1
       end
@@ -73,7 +72,8 @@ RSpec.describe :create_sets_step do
         expect(@sets.first).to have_received(:set_materials).with(uuids)
       end
       it "should lock the set" do
-        expect(@sets.first).to have_received(:update_attributes).with(locked: true)
+        expect(@sets.first).to have_received(:update_attributes).with({
+          locked: true, owner_id: @submission.contact.email})
       end
     end
 


### PR DESCRIPTION
When the owner is set no more updates are allowed for the set we are creating,
so we need to specify the owner setting as the last step of our process.

We need to be careful in future with this feature, as there are some steps that are not going to work after setting this owner in case of the submission set creation (as we give ownership to a different user).  One possibility could be to have an aker user and add an 'as_aker' helper to be able to execute some lines of code as the 'aker' user. Something like:

as_aker { myset.destroy }