### PR TITLE
Renamed 3 labware types and deleted one

### DIFF
--- a/db/migrate/20170928105005_rename_labware_types.rb
+++ b/db/migrate/20170928105005_rename_labware_types.rb
@@ -1,0 +1,22 @@
+class RenameLabwareTypes < ActiveRecord::Migration[5.0]
+  def change
+    # This migration will not explode if the labware types do not exist
+    name_changes = {
+      'ABgene AB_0800' => 'ABgene AB-0800 shallow well PCR plate',
+      'ABgene AB_0859' => 'ABgene AB-0859 deep well plate',
+      '1.5ml' => 'Eppendorf 2.0ml tube',
+    }
+    name_changes.each do |old_name, new_name|
+      lt = LabwareType.find_by(name: old_name)
+      if lt
+        lt.update_attributes(name: new_name)
+      end
+    end
+    fluidx = LabwareType.find_by(name: 'FluidX 0.75ml')
+    if fluidx
+      plate = LabwareType.find_by(name: 'ABgene AB-0800 shallow well PCR plate')
+      MaterialSubmission.where(labware_type_id: fluidx.id).update_all(labware_type_id: plate.id)
+      fluidx.destroy
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170922105201) do
+ActiveRecord::Schema.define(version: 20170928105005) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,6 @@
 # ABgene AB_0800
 LabwareType.create(
-  name: 'ABgene AB_0800',
+  name: 'ABgene AB-0800 shallow well PCR plate',
   description: '0.2ml full skirted clear/colourless 96 well plates (volume <100µl)',
   num_of_cols: 12,
   num_of_rows: 8,
@@ -10,18 +10,8 @@ LabwareType.create(
 
 # ABgene AB_0859
 LabwareType.create(
-  name: 'ABgene AB_0859',
+  name: 'ABgene AB-0859 deep well plate',
   description: '0.8ml clear/colourless storage plate (volume > 100µl)',
-  num_of_cols: 12,
-  num_of_rows: 8,
-  col_is_alpha: false,
-  row_is_alpha: true
-)
-
-# FluidX 0.75
-LabwareType.create(
-  name: 'FluidX 0.75ml',
-  description: '2D barcoded tube rack (volume < 400µl)',
   num_of_cols: 12,
   num_of_rows: 8,
   col_is_alpha: false,
@@ -30,8 +20,8 @@ LabwareType.create(
 
 # 1.5ml foo bar
 LabwareType.create(
-  name: '1.5ml',
-  description: 'foo bar',
+  name: 'Eppendorf 2.0ml tube',
+  description: 'A tube',
   num_of_cols: 1,
   num_of_rows: 1,
   col_is_alpha: false,


### PR DESCRIPTION
Altered seeds to seed the correct labware types.
Migration renames labware types if they exist.
Migration substitutes another labware type for the deleted type in existing submissions.