### PR TITLE
Show submission ID on printed labels

### DIFF
--- a/app/models/printables/group.rb
+++ b/app/models/printables/group.rb
@@ -26,7 +26,7 @@ module Printables::Group
       :top_left            => printable_object[:sanger_human_barcode],
       :bottom_left         => printable_object[:date],
       :top_right           => printable_object[:collaborator_email],
-      :bottom_right        => printable_object[:uricode],
+      :bottom_right        => "Submission #{printable_object[:sub_id]}",
       :top_far_right       => printable_object[:number],
       :bottom_far_right    => "of #{printable_object[:total_number]}",
       :label_counter_right => num_prints(printable_object[:num_prints]),
@@ -37,7 +37,7 @@ module Printables::Group
     {
       :barcode                 => printable_object[:barcode],
       :top_line                => printable_object[:sanger_human_barcode],
-      :middle_line             => printable_object[:uricode],
+      :middle_line             => "Sub. ID: #{printable_object[:sub_id]}",
       :bottom_line             => printable_object[:date],
       :round_label_top_line    => printable_object[:collaborator_email],
       :round_label_bottom_line => 

--- a/app/models/printables/group.rb
+++ b/app/models/printables/group.rb
@@ -37,7 +37,7 @@ module Printables::Group
     {
       :barcode                 => printable_object[:barcode],
       :top_line                => printable_object[:sanger_human_barcode],
-      :middle_line             => "Sub. ID: #{printable_object[:sub_id]}",
+      :middle_line             => "Sub. #{printable_object[:sub_id]}",
       :bottom_line             => printable_object[:date],
       :round_label_top_line    => printable_object[:collaborator_email],
       :round_label_bottom_line => 

--- a/app/models/printer.rb
+++ b/app/models/printer.rb
@@ -31,7 +31,7 @@ private
 				sanger_human_barcode: lw.barcode,
 				date: Date.today.to_s,
 				collaborator_email: submission.owner_email,
-				uricode: '', # Don't know what this is supposed to be
+				sub_id: submission.id,
 				number: i,
 				total_number: submission.labwares.length,
 				num_prints: lw.print_count+1,

--- a/lib/label_templates/aker_tube.rb
+++ b/lib/label_templates/aker_tube.rb
@@ -16,7 +16,7 @@ def tube_barcode_definition(name, type_id, barcode_type)
 		{"horizontal_magnification":"05","vertical_magnification":"05","font":"H","space_adjustment":"02","rotational_angles":"11",
 			"x_origin":"0120","y_origin":"0210","field_name":"top_line"},
 		{"horizontal_magnification":"05","vertical_magnification":"1","font":"G","space_adjustment":"00","rotational_angles":"00",
-			"x_origin":"0240","y_origin":"0165","field_name":"round_label_top_line"},
+			"x_origin":"0220","y_origin":"0165","field_name":"round_label_top_line"},
 		{"horizontal_magnification":"05","vertical_magnification":"1","font":"G","space_adjustment":"00","rotational_angles":"00",
 			"x_origin":"0220","y_origin":"0193","field_name":"round_label_bottom_line"}
 		],


### PR DESCRIPTION
I've replaced the empty URI code field on the barcodes with the submission id, shown as:

- "Submission n" on plate labels
- "Sub. ID: n" on tube labels

Additionally, I've adjusted the x co-ordinate for the email address on tube labels to prevent the ".uk" from being printed off the edge of the label.