### PR TITLE
A168 - option to supply decappers

### DIFF
--- a/app/assets/javascripts/labware.js
+++ b/app/assets/javascripts/labware.js
@@ -17,7 +17,7 @@ function enableDecapper() {
 }
 
 $(document).on("turbolinks:load", function() {
-  $(".labwaretype").click(enableDecapper);
-  $(".supplylabware").click(enableDecapper);
+  $(".labwaretype").change(enableDecapper);
+  $(".supplylabware").change(enableDecapper);
   enableDecapper();
 });

--- a/app/assets/javascripts/labware.js
+++ b/app/assets/javascripts/labware.js
@@ -1,0 +1,23 @@
+// enable/disable the decapper option on the labware page
+
+function isDecappableSelected() {
+  return $(".labwaretype:checked").hasClass("decappable");
+}
+
+function isSupplyLabwareSelected() {
+  return ($(".supplylabware").val()=="true");
+}
+
+function enableDecapper() {
+  if (isDecappableSelected() && isSupplyLabwareSelected()) {
+    $(".supplydecapper").parent().show();
+  } else {
+    $(".supplydecapper").parent().hide();
+  }
+}
+
+$(document).on("turbolinks:load", function() {
+  $(".labwaretype").click(enableDecapper);
+  $(".supplylabware").click(enableDecapper);
+  enableDecapper();
+});

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -161,7 +161,7 @@ private
 
   def material_submission_params
     params.require(:material_submission).permit(
-      :supply_labwares, :no_of_labwares_required, :status, :labware_type_id, :address, :contact_id, :labware
+      :supply_labwares, :supply_decappers, :no_of_labwares_required, :status, :labware_type_id, :address, :contact_id, :labware
     )
   end
 

--- a/app/helpers/material_submissions_helper.rb
+++ b/app/helpers/material_submissions_helper.rb
@@ -5,9 +5,9 @@ module MaterialSubmissionsHelper
     plate.wells.each_with_index.reduce({}) do |memo, list|
       well,index = list[0],list[1]
       memo[index.to_s] = {
-        #:id => well.id.to_s,
-        :position => well.address,
-        :biomaterial_attributes => well.biomaterial_id.nil? ? Biomaterial.new : Biomaterial.find(well.biomaterial_id)
+        #id: well.id.to_s,
+        position: well.address,
+        biomaterial_attributes: well.biomaterial_id.nil? ? Biomaterial.new : Biomaterial.find(well.biomaterial_id)
       }
       memo
     end
@@ -17,9 +17,9 @@ module MaterialSubmissionsHelper
     mlabware = {}
     labwares.each_with_index do |plate, plate_idx|
       mlabware[plate_idx.to_s] = {
-        :id => plate.id.to_s,
-        :barcode => plate.barcode,
-        :wells_attributes => wells_attributes_for(plate)
+        id: plate.id.to_s,
+        barcode: plate.barcode,
+        wells_attributes: wells_attributes_for(plate)
       }
     end
     mlabware
@@ -37,5 +37,12 @@ module MaterialSubmissionsHelper
       end
     end
     return keys
+  end
+
+  def supply_labwares_desc(submission)
+    return '(Not selected)' if submission.supply_labwares.nil?
+    return 'No' unless submission.supply_labwares
+    return 'Yes' unless submission.supply_decappers
+    return 'Yes with decappers'
   end
 end

--- a/app/views/material_submissions/_form.html.erb
+++ b/app/views/material_submissions/_form.html.erb
@@ -5,31 +5,31 @@
   </div>
 
   <div class="field">
-    <%= f.text_field :no_of_labwares_required, :readonly => readonly %>
+    <%= f.text_field :no_of_labwares_required, readonly: readonly %>
   </div>
 
   <div class="field">
-    <%= f.text_field :supply_labwares, :readonly => readonly %>
+    <%= f.text_field :supply_labwares, value: supply_labwares_desc(material_submission), readonly: readonly %>
   </div>
 
   <div class="field">
-    <%= f.select :labware_type, available_labware_types_select_options, {:selected => material_submission.labware_type_id}, {:disabled => readonly } %>
+    <%= f.select :labware_type, available_labware_types_select_options, {selected: material_submission.labware_type_id}, {disabled: readonly } %>
   </div>
 
   <div class="field">
-    <%= f.text_field :status, :readonly => readonly %>
+    <%= f.text_field :status, readonly: readonly %>
   </div>
 
   <div class="field">
-    <%= f.text_field :owner_email, :readonly => readonly %>
+    <%= f.text_field :owner_email, readonly: readonly %>
   </div>
 
   <div class="field">
-    <%= f.text_area :address, style: 'resize: none; width: 100%; height: 10em;', :disabled => readonly %>
+    <%= f.text_area :address, style: 'resize: none; width: 100%; height: 10em;', disabled: readonly %>
   </div>
 
   <div class="field">
-    <%= f.select :contact, available_contacts_select_options, {:selected => material_submission.contact_id}, {:disabled => readonly }%>
+    <%= f.select :contact, available_contacts_select_options, {selected: material_submission.contact_id}, {disabled: readonly }%>
   </div>
 
   <% if material_submission.labwares.any? { |lw| lw.barcode } %>

--- a/app/views/material_submissions/_material_submission.html.erb
+++ b/app/views/material_submissions/_material_submission.html.erb
@@ -1,7 +1,7 @@
 <tr>
   <td><%= material_submission.labware_type&.name || '(Not selected)' %></td>
   <td><%= material_submission.no_of_labwares_required %></td>
-  <td><%= material_submission.supply_labwares.nil? ? '(Not selected)' : material_submission.supply_labwares %></td>
+  <td><%= supply_labwares_desc(material_submission) %></td>
   <td><%= localize(material_submission.updated_at, format: :terse) %></td>
   <td>
     <% if material_submission.active? %>

--- a/app/views/submissions/labware.html.erb
+++ b/app/views/submissions/labware.html.erb
@@ -2,14 +2,23 @@
 
 <%= bootstrap_form_for material_submission, url: wizard_path, method: :put  do |f| %>
 
-  <%= f.collection_radio_buttons(:labware_type_id, LabwareType.all, :id, :name,
-    label: '1) How would you like to submit your material?') %>
+  <%= f.form_group :labwar_type_id, label: { text: "1) How would you like to submit your material?" } do %>
+    <% LabwareType.all.each do |lt| %>
+      <% classes = lt.uses_decapper ? "labwaretype decappable" : "labwaretype" %>
+      <%= f.radio_button :labware_type_id, lt.id, label: lt.name, class: classes %>
+    <% end %>
+  <% end %>
 
   <%= f.number_field :no_of_labwares_required,
-    label: '2) How many plates or tubes do you require?', min: 0, step: 1 %>
+  label: '2) How many plates or tubes do you require?', min: 0, step: 1 %>
 
   <%= f.select :supply_labwares, [['No', false], ['Yes', true]],
-    label: '3) Do you require plates or tubes to be supplied to you?' %>
+  {label: '3) Do you require plates or tubes to be supplied to you?'},
+  { class: 'supplylabware' } %>
+
+  <%= f.select :supply_decappers, [['No', false], ['Yes', true]],
+  { label: '4) Do you require decappers to be supplied to you?' },
+  { class: 'supplydecapper' } %>
 
   <%= render 'buttons', material_submission: material_submission, f: f %>
 

--- a/db/migrate/20171017142510_add_decapper_columns.rb
+++ b/db/migrate/20171017142510_add_decapper_columns.rb
@@ -1,0 +1,6 @@
+class AddDecapperColumns < ActiveRecord::Migration[5.0]
+  def change
+    add_column :labware_types, :uses_decapper, :boolean, null: false, default: false
+    add_column :material_submissions, :supply_decappers, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170928105005) do
+ActiveRecord::Schema.define(version: 20171017142510) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,8 +44,9 @@ ActiveRecord::Schema.define(version: 20170928105005) do
     t.boolean  "row_is_alpha"
     t.string   "name"
     t.string   "description"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.boolean  "uses_decapper", default: false, null: false
   end
 
   create_table "labwares", force: :cascade do |t|
@@ -74,13 +75,14 @@ ActiveRecord::Schema.define(version: 20170928105005) do
     t.boolean  "supply_labwares"
     t.integer  "labware_type_id"
     t.string   "status"
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
     t.text     "address"
     t.integer  "contact_id"
     t.uuid     "set_id"
     t.string   "material_submission_uuid"
     t.string   "owner_email"
+    t.boolean  "supply_decappers",         default: false, null: false
     t.index ["contact_id"], name: "index_material_submissions_on_contact_id", using: :btree
     t.index ["labware_type_id"], name: "index_material_submissions_on_labware_type_id", using: :btree
     t.index ["owner_email"], name: "index_material_submissions_on_owner_email", using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,7 +29,7 @@ LabwareType.create(
 )
 
 LabwareType.create(
-  name: 'FluidX 0.75ml tubes in rack',
+  name: 'Rack of FluidX 0.75ml tubes',
   description: 'A rack of tubes',
   num_of_cols: 12,
   num_of_rows: 8,
@@ -39,7 +39,7 @@ LabwareType.create(
 )
 
 LabwareType.create(
-  name: 'FluidX 0.3ml tubes in rack',
+  name: 'Rack of FluidX 0.3ml tubes',
   description: 'A rack of tubes',
   num_of_cols: 12,
   num_of_rows: 8,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,35 +28,55 @@ LabwareType.create(
   row_is_alpha: false
 )
 
+LabwareType.create(
+  name: 'FluidX 0.75ml tubes in rack',
+  description: 'A rack of tubes',
+  num_of_cols: 12,
+  num_of_rows: 8,
+  col_is_alpha: false,
+  row_is_alpha: true,
+  uses_decapper: true
+)
+
+LabwareType.create(
+  name: 'FluidX 0.3ml tubes in rack',
+  description: 'A rack of tubes',
+  num_of_cols: 12,
+  num_of_rows: 8,
+  col_is_alpha: false,
+  row_is_alpha: true,
+  uses_decapper: true
+)
+
 Contact.create(
   fullname: Forgery('name').full_name,
   email: Forgery('internet').email_address
-  )
+)
 
 Contact.create(
   fullname: "Dave",
   email: "dr6@sanger.ac.uk"
-  )
+)
 Contact.create(
   fullname: "Harriet",
   email: "hc6@sanger.ac.uk"
-  )
+)
 Contact.create(
   fullname: "Rich",
   email: "rl15@sanger.ac.uk"
-  )
+)
 Contact.create(
   fullname: "Eduardo",
   email: "emr@sanger.ac.uk"
-  )
+)
 Contact.create(
   fullname: "Chris",
   email: "cs24@sanger.ac.uk"
-  )
-  Contact.create(
-    fullname: "Phil",
-    email: "pj5@sanger.ac.uk"
-    )
+)
+Contact.create(
+  fullname: "Phil",
+  email: "pj5@sanger.ac.uk"
+)
 
 Printer.create(
   name: 'd304bc',

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe SubmissionsController, type: :controller do
           when :labware
             {
               supply_labwares: true,
+              supply_decappers: true,
               no_of_labwares_required: 1,
               status: 'labware',
               labware_type_id: labware_type.id
@@ -74,7 +75,8 @@ RSpec.describe SubmissionsController, type: :controller do
   let(:labware_type) do
     FactoryGirl.create :labware_type, {
       num_of_cols: 1,
-      num_of_rows: 1
+      num_of_rows: 1,
+      uses_decapper: true,
     }
   end
 
@@ -162,7 +164,7 @@ RSpec.describe SubmissionsController, type: :controller do
         allow(controller).to receive(:current_user).and_return(user)
       end
 
-      it "does not update the submission if the state is not pending (ie broken)" do
+      it "does not update the submission if the state is not pending (i.e. broken)" do
         allow_any_instance_of(DispatchService).to receive(:process).and_raise  "This step fails"
         allow_any_instance_of(ProvenanceService).to receive(:validate).and_return []
 
@@ -209,6 +211,7 @@ RSpec.describe SubmissionsController, type: :controller do
 
         put :update, step_params(material_submission, :labware)
         material_submission.reload
+        expect(material_submission.supply_decappers).to eq(true)
 
         put :biomaterial_data, step_params(material_submission, :provenance)
         material_submission.reload

--- a/spec/factories/labware_types.rb
+++ b/spec/factories/labware_types.rb
@@ -26,4 +26,14 @@ FactoryGirl.define do
     name "Tube"
     description "A tube"
   end
+
+  factory :rack_labware_type, class: LabwareType do
+    num_of_cols 12
+    num_of_rows 8
+    col_is_alpha false
+    row_is_alpha false
+    uses_decapper true
+    name "Rack"
+    description "A rack"
+  end
 end

--- a/spec/models/material_submission_spec.rb
+++ b/spec/models/material_submission_spec.rb
@@ -475,7 +475,7 @@ RSpec.describe MaterialSubmission, type: :model do
         labware_type = create(:labware_type)
         @material_submission = create(:material_submission, labware_type: labware_type, supply_labwares: false)
       end
-      it "expect supply labware type to show 'Label only" do
+      it "should return 'Label only'" do
         expect(@material_submission.supply_labware_type).to eq 'Label only'
       end
     end
@@ -484,10 +484,50 @@ RSpec.describe MaterialSubmission, type: :model do
         labware_type = create(:plate_labware_type)
         @material_submission = create(:material_submission, labware_type: labware_type, supply_labwares: true)
       end
-      it "expect supply labware type to show 'Label only" do
+      it "should return the labware type name" do
         expect(@material_submission.supply_labware_type).to eq 'Plate'
       end
     end
+
+    context "when the submission needs decappers" do
+      before do
+        labware_type = create(:rack_labware_type)
+        @material_submission = create(:material_submission, labware_type: labware_type, supply_labwares: true, supply_decappers: true)
+      end
+      it "should return the labware type name with decappers" do
+        expect(@material_submission.supply_labware_type).to eq 'Rack with decappers'
+      end
+    end
+  end
+
+  describe '#supply_decappers' do
+    # supply_decappers cannot be true unless the labware type supports it, and supply_labwares is true.
+
+    let(:uses_decappers) { true }
+    let(:supply_labwares) { true }
+    let(:supply_decappers) { true }
+    let(:labware_type) { create(uses_decappers ? :rack_labware_type : :labware_type) }
+    let(:submission) { create(:material_submission, labware_type: labware_type, supply_labwares: supply_labwares, supply_decappers: supply_decappers) }
+
+    context "when the labware type does not use decappers" do
+      let(:uses_decappers) { false }
+      it { expect(submission.supply_decappers).to eq(false) }
+    end
+
+    context "when supply labwares is false" do
+      let(:supply_labwares) { false }
+      it { expect(submission.supply_decappers).to eq(false) }
+    end
+
+    context "when supply decappers is false" do
+      let(:supply_decappers) { false }
+      it { expect(submission.supply_decappers).to eq(false) }
+    end
+
+    context "when the labware type uses decappers, supply labwares is true, and supply decappers is true" do
+      it { expect(submission.supply_decappers).to eq(true) }
+    end
+
   end
 
 end


### PR DESCRIPTION
Some labware types use decappers.
Submissions have a 'supply decappers' option.
The option is only applicable where the labware type uses decappers, and the submission
has 'supply labwares' also set to true.
Where 'supply labwares' is viewable, it can be shown as
'Yes', or 'Yes with decappers'.
I had to add some javascript to hide/show the supply-decappers input
when you select labware type or set 'supply labware' to be true or false.