### PR TITLE
Added version number

### DIFF
--- a/app/views/submissions/_submission_header.html.erb
+++ b/app/views/submissions/_submission_header.html.erb
@@ -15,6 +15,8 @@
 <div class="row">
   <div class="col-md-12">
     <%= render "error_messages", target: material_submission %>
+    <div id="warning-messages" class="alert alert-warning hidden" role="alert">
+    </div>    
   </div>
 </div>
 


### PR DESCRIPTION
Merge devel into staging (#122)

* Fix timestamp shown when receiving a material

* Also added moment.js which is very useful for date/time operations in JS.

* Fixed ordering in material reception by barcode, then received at

* Set date_of_receipt on Material Reception (#121)

* Set date_of_receipt on Material Reception

* Added comment re pythons current datetime format

New requirements.txt file for ansible

requirements

requirements

remove requirements

Added warning when the manifest contains a scientific name, as it is
overwritten by taxon service
Added warning mark to each input that has a changed scientific name
after loading a manifest