### PR TITLE
Add name indexes

### DIFF
--- a/db/migrate/20171206110335_add_name_indexes.rb
+++ b/db/migrate/20171206110335_add_name_indexes.rb
@@ -1,0 +1,6 @@
+class AddNameIndexes < ActiveRecord::Migration[5.0]
+  def change
+    add_index :label_templates, :name, unique: true
+    add_index :labware_types, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171201151450) do
+ActiveRecord::Schema.define(version: 20171206110335) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 20171201151450) do
     t.integer  "external_id",   null: false
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
+    t.index ["name"], name: "index_label_templates_on_name", unique: true, using: :btree
   end
 
   create_table "labware_types", force: :cascade do |t|
@@ -49,6 +50,7 @@ ActiveRecord::Schema.define(version: 20171201151450) do
     t.datetime "created_at",                    null: false
     t.datetime "updated_at",                    null: false
     t.boolean  "uses_decapper", default: false, null: false
+    t.index ["name"], name: "index_labware_types_on_name", unique: true, using: :btree
   end
 
   create_table "labwares", force: :cascade do |t|

--- a/spec/factories/labware_types.rb
+++ b/spec/factories/labware_types.rb
@@ -5,8 +5,12 @@ FactoryBot.define do
     num_of_rows 8
     col_is_alpha false
     row_is_alpha false
-    name "Labware"
+    name { generate(:labware_type_names) }
     description "A piece of labware"
+  end
+
+  sequence :labware_type_names do |n|
+    "labware_type_#{n}"
   end
 
   factory :plate_labware_type, class: LabwareType do


### PR DESCRIPTION
If names are supposed to uniquely identify a record, they should have a unique index.
Added unique index on name for label templates and labware types.