### PR TITLE
Remove floating header on submission table

### DIFF
--- a/app/assets/javascripts/load_table.js
+++ b/app/assets/javascripts/load_table.js
@@ -4,11 +4,7 @@ $(document).on('turbolinks:load', function() {
     .DataTable({
       paging: false,
       searching: false,
-      ordering: false,
-      fixedHeader: {
-        header: true,
-        footer: false
-      }
+      ordering: false
     })
     .on('drag dragstart dragend dragover dragenter dragleave drop', function(e) {
       e.preventDefault();

--- a/app/views/submissions/provenance.html.erb
+++ b/app/views/submissions/provenance.html.erb
@@ -150,14 +150,14 @@
                     <td data-psd-schema-validation-name="<%= col %>">
                       <div class="form-group">
                         <% if material_schema["properties"][col]['allowed'] %>
-                          <select class="form-control"
+                          <select class="form-control" title="<%= schema['properties'][col]['friendly_name'] || col %>"
                                   name="material_submission[labware][<%= labware.labware_index %>][<%= address %>][<%= col %>]"
                                   id="labware[<%= labware.labware_index %>]address[<%= address %>]fieldName[<%= col %>]">
                             <option value=""></option>
                             <%= options_for_select(material_schema["properties"][col]['allowed'], (labware.contents[address][col] if labware.contents.present? && labware.contents[address].present? && labware.contents[address][col].present?))%>
                           </select>
                         <% else %>
-                          <input class="form-control"
+                          <input class="form-control" title="<%= schema['properties'][col]['friendly_name'] || col %>"
                                 type="<%= material_schema["properties"][col]["field_type"] || 'text' %>"
                                 name="material_submission[labware][<%= labware.labware_index %>][<%= address %>][<%= col %>]"
                                 id="labware[<%= labware.labware_index %>]address[<%= address %>]fieldName[<%= col %>]"


### PR DESCRIPTION
This is a fix/workaround for the floating header of the submission form not moving when the table is scrolled horizontally. The issue occurs due to a limitation of DataTables.

Floating header has been disabled and tooltips added to each field indicating what column they're for