### PR TITLE
A211 - integrate with new test ehmdmc service

### DIFF
--- a/app/assets/javascripts/data_table_schema_validation.js
+++ b/app/assets/javascripts/data_table_schema_validation.js
@@ -87,7 +87,7 @@
   proto.hmdmcCheck = function(fieldProperties, hmdmcField) {
     // Only validate the HMDMC number if there is one
     if (hmdmcField.value) {
-      var hmdmcPattern = new RegExp('^[0-9]{2}\/[0-9]{3}$');
+      var hmdmcPattern = new RegExp('^[0-9]{2}\/[0-9]{3,4}$');
 
       // First validate that the HMDMC field is in the correct format
       if (hmdmcPattern.test(hmdmcField.value)) {

--- a/app/views/submissions/provenance.html.erb
+++ b/app/views/submissions/provenance.html.erb
@@ -115,7 +115,9 @@
               </div>
             </div>
           </div>
-          <p style="color:red">&#9888; All HMDMC numbers will be saved, but not validated with eHMDMC.</p>
+          <% if Rails.configuration.show_hmdmc_warning %>
+            <p style="color:red">&#9888; All HMDMC numbers will be saved, but not validated with eHMDMC.</p>
+          <% end %>
           <p><strong>Note:</strong> If necessary, the table can be scrolled horizontally to view all of the fields</p>
 
           <div style="overflow: scroll;">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,8 +71,9 @@ Rails.application.configure do
 
   config.stamp_url = 'http://localhost:7000/api/v1/'
 
-  config.ehmdmc_url = 'http://localhost:3501/validate'
-  config.ehmdmc_url_default_proxy = 'http://localhost:3501'
+  config.ehmdmc_url = 'http://web-wwwtomcatdev-02.internal.sanger.ac.uk:8000/validateHMDMC'
+  # For local fake hmdmc, use http://localhost:3501/validate
+
   config.pmb_uri = ENV.fetch('PMB_URI', 'http://localhost:10000/v1')
 
   config.taxonomy_service_url = 'https://www.ebi.ac.uk/ena/data/taxonomy/v1/taxon/tax-id'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,6 +73,7 @@ Rails.application.configure do
 
   config.ehmdmc_url = 'http://web-wwwtomcatdev-02.internal.sanger.ac.uk:8000/validateHMDMC'
   # For local fake hmdmc, use http://localhost:3501/validate
+  config.show_hmdmc_warning = true
 
   config.pmb_uri = ENV.fetch('PMB_URI', 'http://localhost:10000/v1')
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,8 +71,8 @@ Rails.application.configure do
 
   config.stamp_url = 'http://localhost:7000/api/v1/'
 
-  config.ehmdmc_url = 'http://web-wwwtomcatdev-02.internal.sanger.ac.uk:8000/validateHMDMC'
-  # For local fake hmdmc, use http://localhost:3501/validate
+  config.ehmdmc_url = 'http://localhost:3501/validate'
+  # The external test hmdmc is at http://web-wwwtomcatdev-02.internal.sanger.ac.uk:8000/validateHMDMC
   config.show_hmdmc_warning = true
 
   config.pmb_uri = ENV.fetch('PMB_URI', 'http://localhost:10000/v1')

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,6 +53,7 @@ Rails.application.configure do
   config.aker_deployment_default_proxy = {}
 
   config.ehmdmc_url = 'http://localhost:3501/validate'
+  config.show_hmdmc_warning = false
 
   config.printing_disabled = true
 

--- a/lib/ehmdmc_client.rb
+++ b/lib/ehmdmc_client.rb
@@ -4,9 +4,28 @@ module EHMDMCClient
 
   def self.validate?(hmdmc)
     r = connection.get('?hmdmc=' + sanitise(hmdmc))
-    return true if r.status==200
-    Rails.logger.info "Attempting to validate HMDMC #{hmdmc} returned status code #{r.status}"
-    false
+    unless r.status==200
+      # Something went wrong
+      Rails.logger.error "Attempting to validate HMDMC #{hmdmc} returned status code #{r.status}"
+      return false
+    end
+    begin
+      data = JSON.parse(r.body)
+    rescue JSON::ParserError
+      Rails.logger.error "Attempting to validate HMDMC #{hmdmc} produced invalid JSON: #{r.body}"
+      return false
+    end
+    return true if data['valid']
+    # The HMDMC was refused
+    Rails.logger.info "HMDMC rejected: #{hmdmc}, error code: #{data['errorcode']}"
+    # Error codes, from Stephen Rice:
+    # 0: no error (valid)
+    # 1: system error
+    # 2: syntax error, i.e. malformed HMDMC number
+    # 3: number has correct syntax but does not exist in system
+    # 4: number does exist in system but is not approved
+    # 5: valid but failed to find any product classes
+    return false
   end
 
   def self.sanitise(hmdmc)
@@ -14,6 +33,6 @@ module EHMDMCClient
   end
 
   def self.connection
-    Faraday.new(:url => Rails.application.config.ehmdmc_url)
+    Faraday.new(url: Rails.application.config.ehmdmc_url)
   end
 end

--- a/lib/schema_validators/biomaterial_schema_property_validators/hmdmc_validator.rb
+++ b/lib/schema_validators/biomaterial_schema_property_validators/hmdmc_validator.rb
@@ -18,8 +18,8 @@ module SchemaValidators
           return 'Only human material are to have HMDMC numbers associated.'
         end
         # Check format validity
-        unless hmdmc_number.match(/^[0-9]{2}\/[0-9]{3}$/)
-          return 'The HMDMC number must be of the format ##/###.'
+        unless hmdmc_number.match(/^[0-9]{2}\/[0-9]{3,4}$/)
+          return 'The HMDMC number must be of the format ##/####.'
         end
         # Check the actual number with the HMDMC service
         unless EHMDMCClient.validate?(hmdmc_number)


### PR DESCRIPTION
HMDMCs are now expected to be ##/#### (2/4 instead of 2/3). Accept
either 2/3 or 2/4 as correctly formed, for now.
There is a new test eHMDMC server. The url for this replaces
a localhost url in the development.rb config.
The new eHMDMC server returns a block of json specifying if the
HMDMC code is valid or not. The ehmdmc_client has been
correspondingly altered.