### PR TITLE
This commit solves the problem with the incorrect JSON generated from…

### DIFF
--- a/app/assets/javascripts/data_table_schema_validation.js
+++ b/app/assets/javascripts/data_table_schema_validation.js
@@ -80,6 +80,24 @@
     return false;
   };
 
+  proto.hmdmcAjaxSuccess = function(hmdmcField, hmdmcResponseJson) {
+    if (typeof hmdmcResponseJson.valid !== 'undefined') {
+      // We cache that the HMDMC number is valid, so next time we won't repeat the same request
+      this.verifiedHMDMC[hmdmcField.value] = hmdmcResponseJson.valid;
+    }
+    if (!!hmdmcResponseJson.valid) {
+      // If the service says its valid, we can apply the schema validation
+        $(hmdmcField.node).trigger('psd.schema.validation', {
+          node: hmdmcField.node,
+          name: hmdmcField.name,
+          value: hmdmcField.value
+        });      
+    } else {
+      // If it is not valid, we display the error sent back from the server
+      this.validationError(hmdmcField.node, hmdmcField.name, hmdmcResponseJson.error_message || 'Unspecified HDMMC problem');
+    }
+  };
+
   /**
    * Fails if the HMDMC number is invalid
    * Returns true if it fails.
@@ -105,18 +123,11 @@
             url: "/hmdmc",
             method: "GET",
             data: { hmdmc: hmdmcField.value.replace("/", "_") },
-            success: $.proxy(function(validHMDMC) {
-              this.verifiedHMDMC[hmdmcField.value] = validHMDMC;
-              $(hmdmcField.node).trigger('psd.schema.validation', {
-                node: hmdmcField.node,
-                name: hmdmcField.name,
-                value: hmdmcField.value
-              });
-            }, this)
+            success: $.proxy(this.hmdmcAjaxSuccess, this, hmdmcField)
           });
         }
       } else {
-        var hmdmcFormatError = "The HMDMC number should be in the format ##/###."
+        var hmdmcFormatError = "The HMDMC number should be in the format ##/####."
         this.validationError(hmdmcField.node, hmdmcField.name, hmdmcFormatError);
         return true;
       }

--- a/app/controllers/material_submissions_controller.rb
+++ b/app/controllers/material_submissions_controller.rb
@@ -8,7 +8,7 @@ class MaterialSubmissionsController < ApplicationController
 
   # Action to handle validating HMDMC from JavaScript
   def hmdmc_validate
-    render :json => EHMDMCClient.validate?(params[:hmdmc])
+    render :json => EHMDMCClient.validate_hmdmc(params[:hmdmc]).to_json
   end
 
   def index

--- a/lib/ehmdmc_client.rb
+++ b/lib/ehmdmc_client.rb
@@ -2,22 +2,114 @@ require 'faraday'
 
 module EHMDMCClient
 
-  def self.validate?(hmdmc)
-    r = connection.get('?hmdmc=' + sanitise(hmdmc))
-    unless r.status==200
-      # Something went wrong
-      Rails.logger.error "Attempting to validate HMDMC #{hmdmc} returned status code #{r.status}"
-      return false
+  class Validation
+    # This class will store the message for the error produced by the HMDMC service provider, 
+    # depending on the type of error it will generate a different content. Its purpose is to solve
+    # the following problems:
+    # - Publish the error message to the Logging facility to be able to track the problem
+    # - Provide to the user a meaningful text indicating the problem but without giving too much
+    # details about the internal process
+    # - Depending on the type of error, be able to know if the validation already happened (is_validated)
+    # or if we would need to retry in future, because it has not been validated
+    # - Indicate, when the validation has been performed, if the hmdmc is considered valid or not
+    # - Generate a valid json message for the client to display the relevant information for the user
+
+    attr_reader :error_message, :hmdmc, :text
+
+    def initialize(hmdmc)
+      @hmdmc = hmdmc
+      reset
     end
+
+    def reset
+      @validated = true
+      @valid = true      
+    end
+
+    def is_validated?
+      @validated
+    end
+
+    def valid?
+      @validated && @valid
+    end
+
+    def log
+      Rails.logger.send(@facility, @text) unless @text.nil?
+    end
+
+    def load_message(type_of_message, facility, text, validated)
+      not_validated_msg = "The HMDMC #{hmdmc} is considered as not valid by the HMDMC service"
+      unknown_validation_msg = 'We cannot validate with the HMDMC service at now. Please contact the administrators if the problem persists.'
+
+      # Type of message loaded.
+      # Valid values:
+      # - :user_message means that the message can be displayed to the user
+      # - :infrastructure_message means that the message describes some internal information that
+      #      is not relevant for the user, although it is for the logging.
+      @type_of_message = type_of_message 
+
+      # Level of logging where the message will be emitted
+      # Valid values: Any facility understood by Rails.logger like :info, :error, ...
+      @facility = facility
+
+      # Text with the content of the message
+      @text = text
+
+      # Indicates if this error message means that a validation process has been completed
+      # Some errors (like connection failed) do not mean that the validation happened
+      @validated = validated
+
+      # This field 'valid' will indicate if the HMDMC has been considered valid or invalid by the service
+      # If the service could not give an answer about it, it won't be marked as valid or invalid by the message (for example, when
+      # we query the service but at that moment is down, we cannot consider it as not valid)
+      @valid = @validated ?  @text.nil? : nil
+
+      # This field 'error_message' will give as the error message that we can display to the user. 
+      # There are some errors that are infrastructure-specific (json invalid, error codes, etc...) not 
+      # relevant for the user. In these cases, a generic message will be provided, instead of the 
+      # message loaded.
+      unless @text.nil?
+        if (@type_of_message == :infrastructure_message)
+          @error_message = @validated ? not_validated_msg : unknown_validation_msg
+        elsif (@type_of_message == :user_message)
+          @error_message = @text
+        end
+      end
+
+      log
+
+      # Needs to return self
+      return self
+    end
+
+    def to_json
+      {valid: @valid, error_message: @error_message}.reject{|k,v| v.nil?}.to_json
+    end
+  end
+
+  def self.get_response_for_hmdmc(hmdmc)
+    begin
+      r = connection.get('?hmdmc=' + sanitise(hmdmc))
+      return r
+    rescue Faraday::ConnectionFailed => e
+      return nil
+    end
+  end
+
+  def self.validate_hmdmc(hmdmc)
+    msg = Validation.new(hmdmc)
+
+    r = get_response_for_hmdmc(hmdmc)
+    return msg.load_message(:user_message, :info, 'Connection to HMDMC service failed', false) unless r
+    return msg.load_message(:infrastructure_message, :error, "Attempting to validate HMDMC #{hmdmc} returned status code #{r.status}", true) unless r.status == 200
+
     begin
       data = JSON.parse(r.body)
     rescue JSON::ParserError
-      Rails.logger.error "Attempting to validate HMDMC #{hmdmc} produced invalid JSON: #{r.body}"
-      return false
+      return msg.load_message(:infrastructure_message, :error, "Attempting to validate HMDMC #{hmdmc} produced invalid JSON: #{r.body}", false)
     end
-    return true if data['valid']
-    # The HMDMC was refused
-    Rails.logger.info "HMDMC rejected: #{hmdmc}, error code: #{data['errorcode']}"
+
     # Error codes, from Stephen Rice:
     # 0: no error (valid)
     # 1: system error
@@ -25,7 +117,8 @@ module EHMDMCClient
     # 3: number has correct syntax but does not exist in system
     # 4: number does exist in system but is not approved
     # 5: valid but failed to find any product classes
-    return false
+    return msg.load_message(:infrastructure_message, :info, "HMDMC rejected: #{hmdmc}, error code: #{data['errorcode']}", true) unless data['valid']
+    return msg
   end
 
   def self.sanitise(hmdmc)

--- a/lib/schema_validators/biomaterial_schema_property_validators/hmdmc_validator.rb
+++ b/lib/schema_validators/biomaterial_schema_property_validators/hmdmc_validator.rb
@@ -22,8 +22,9 @@ module SchemaValidators
           return 'The HMDMC number must be of the format ##/####.'
         end
         # Check the actual number with the HMDMC service
-        unless EHMDMCClient.validate?(hmdmc_number)
-          return "The HMDMC number #{hmdmc_number} could not be validated with the eHMDMC service."
+        validation = EHMDMCClient.validate_hmdmc(hmdmc_number)
+        unless validation.valid?
+          return validation.error_message
         end
       end
 

--- a/spec/lib/ehmdmc_client_spec.rb
+++ b/spec/lib/ehmdmc_client_spec.rb
@@ -1,0 +1,243 @@
+require 'rails_helper'
+
+require 'ehmdmc_client'
+
+RSpec.describe 'EHMDMCClient' do
+
+  context 'EHMDMCClient' do
+
+    context '#get_response_for_hmdmc' do
+      let(:connection) { double('connection')}
+      let(:response) { double('response') }
+      before do
+        allow(Faraday).to receive(:new).and_return(connection)
+      end
+
+      it 'returns a connection when successful' do
+        allow(connection).to receive(:get).and_return(response)
+        val = EHMDMCClient.get_response_for_hmdmc('1234')
+        expect(val).to eq(response)
+      end
+      it 'returns nil when connection failed' do
+        allow(connection).to receive(:get).and_raise(Faraday::ConnectionFailed, 'some desc')
+        val = EHMDMCClient.get_response_for_hmdmc('1234')
+        expect(val).to eq(nil)
+      end      
+    end
+
+    context '#validate_hmdmc' do
+      let(:connection) { double('connection')}
+      let(:hmdmc) { '1234'}
+      let(:response) { double('response') }
+      before do
+        allow(Faraday).to receive(:new).and_return(connection)
+      end
+      context 'when the connection fails' do
+        it 'returns a service failed message' do
+          allow(connection).to receive(:get).and_raise(Faraday::ConnectionFailed, 'some desc')
+          msg = EHMDMCClient.validate_hmdmc(hmdmc)
+          expect(msg.text).to include('service failed')
+        end
+      end
+      context 'when the connection is right' do
+        before do
+          allow(connection).to receive(:get).and_return(response)
+        end
+
+        context 'when the http code is not 200' do
+          before do
+            allow(response).to receive(:status).and_return(500)
+          end
+          it 'returns a status code message' do
+            msg = EHMDMCClient.validate_hmdmc(hmdmc)
+            expect(msg.text).to include('status code')
+          end          
+        end
+
+        context 'when the http code is 200' do
+          before do
+            allow(response).to receive(:status).and_return(200)
+            allow(response).to receive(:body).and_return("{}")
+          end
+
+          context 'when there is a json parsing error' do
+            before do
+              allow(JSON).to receive(:parse).and_raise(JSON::ParserError)  
+            end
+            it 'returns a invalid JSON message' do
+              msg = EHMDMCClient.validate_hmdmc(hmdmc)
+              expect(msg.text).to include('invalid JSON')              
+            end
+          end
+
+          context 'when the parsing is correct' do           
+            context 'when valid attribute is not set to true by the hmdmc service' do
+              let(:json_object) { { valid: false, errorcode: 1 }.to_json }  
+              before do
+                allow(response).to receive(:body).and_return(json_object)
+              end
+              it 'returns a rejected message' do
+                msg = EHMDMCClient.validate_hmdmc(hmdmc)
+                expect(msg.text).to include('rejected')
+              end
+              it 'indicates that is not valid' do
+                msg = EHMDMCClient.validate_hmdmc(hmdmc)
+                expect(msg.valid?).to eq(false)
+              end
+              it 'indicates that is validated' do
+                msg = EHMDMCClient.validate_hmdmc(hmdmc)
+                expect(msg.is_validated?).to eq(true)
+              end
+
+            end
+            context 'when valid attribute is set to true by the hmdmc service' do
+              let(:json_object) { { valid: true, errorcode: 1 }.to_json }  
+              before do
+                allow(response).to receive(:body).and_return(json_object)
+              end
+              it 'returns a nil message' do
+                msg = EHMDMCClient.validate_hmdmc(hmdmc)
+                expect(msg.text).to eq(nil)
+              end
+
+              it 'indicates that is valid' do
+                msg = EHMDMCClient.validate_hmdmc(hmdmc)
+                expect(msg.valid?).to eq(true)
+              end
+              it 'indicates that is validated' do
+                msg = EHMDMCClient.validate_hmdmc(hmdmc)
+                expect(msg.is_validated?).to eq(true)
+              end
+
+            end
+
+          end
+        end
+
+      end
+    end
+  end
+
+  context 'EHMDMCClient::Validation' do
+    let(:hmdmc) { '1234' }
+    let(:obj) { EHMDMCClient::Validation.new(hmdmc) }
+    let(:msg) { 'some text' }
+    let(:generic_msg) { "The HMDMC #{hmdmc} is considered as not valid by the HMDMC service" }
+    before do
+      Rails.logger = double('logger')
+      allow(Rails.logger).to receive(:info)
+      allow(Rails.logger).to receive(:error)
+    end
+
+    context '#to_json' do
+      context 'if the hmdmc has not been validated' do
+        before do
+          obj.load_message(:user_message, :info, 'some problem', false)
+        end
+        it 'does not generate a json with the valid field' do
+          m = JSON.parse(obj.to_json).symbolize_keys
+          expect(m[:valid]).to eq(nil)
+        end
+      end
+      context 'if the hmdmc has been validated' do
+        before do
+          obj.load_message(:user_message, :info, 'some problem', true)
+        end        
+        it 'does generates a json with the valid field' do
+          m = JSON.parse(obj.to_json).symbolize_keys
+          expect(m[:valid]).to eq(false)
+        end
+      end      
+    end
+
+    context '#load_message' do
+      it 'returns the same instance' do
+        msg = obj.load_message(:user_message, :info,'some msg',false)
+        expect(obj).to eq(msg)
+      end
+
+      context 'with argument: facility' do
+        context 'when the facility specified is :info' do
+          it 'writes the message to Rails.logger.info' do
+            obj.load_message(:infrastructure_message, :info, msg,true)
+            expect(Rails.logger).to have_received(:info).with(msg)
+          end
+        end
+
+        context 'when the facility specified is :error' do
+          it 'writes the message to Rails.logger.error' do
+            obj.load_message(:infrastructure_message, :error, msg,true)
+            expect(Rails.logger).to have_received(:error).with(msg)
+          end
+        end
+      end
+
+      context 'with argument: type_of_message' do
+        context ':user_message' do
+          before do
+            obj.load_message(:user_message, :info, msg, true)
+          end
+          it 'sets the loaded message for the user' do
+            expect(obj.error_message).to eq(msg)
+          end
+        end
+        context ':infrastructure_message' do
+          before do
+            obj.load_message(:infrastructure_message, :info, msg, true)
+          end
+          it 'sets a generic message for the user' do
+            expect(obj.error_message).to eq(generic_msg)
+          end
+        end
+      end
+
+      context 'with argument: valid' do
+        context 'when no messages have been loaded' do
+          it 'marks the message as valid' do
+            expect(obj.valid?).to eq(true)
+          end
+          it 'identifies the message as validated' do
+            expect(obj.is_validated?).to eq(true)
+          end                      
+        end
+        context 'when a message has been previously loaded' do
+          context 'when the loaded message is identified as not validated' do
+            before do
+              obj.load_message(:infrastructure_message, :info, nil, false)
+            end
+            it 'does not mark the message as valid' do
+              expect(obj.valid?).to eq(false)
+            end
+            it 'identifies the message as not validated' do
+              expect(obj.is_validated?).to eq(false)
+            end            
+          end
+          context 'when the loaded message is identified as validated' do
+            context 'when some text was added by the message' do
+              before do
+                obj.load_message(:infrastructure_message, :info, 'some error', true)
+              end
+              it 'marks the message as invalid' do
+               expect(obj.valid?).to eq(false) 
+              end
+              it 'identifies the message as validated' do
+                expect(obj.is_validated?).to eq(true)
+              end              
+            end
+            context 'when no text is stored' do
+              before do
+                obj.load_message(:infrastructure_message, :info, nil, true)
+              end
+              it 'marks the message as valid ' do
+               expect(obj.valid?).to eq(true) 
+              end
+              it 'identifies the message as validated' do
+                expect(obj.is_validated?).to eq(true)
+              end              
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
… the server in case of connection failed when the HMDMC server is down.

Provide a description about the hmdmc validation with a meaningful description
to the user and with a logging message to be able to track exactly the problem.
The message will also indicate to the user if the HMDMC has been rejected because it is invalid, or because it could not been validated.
If the HMDMC could not been validated, the UI will retry it in every blur
event and when clicking Next.
If the HMDC has been validated and has been considered valid or invalid, the
UI will cache the answer and won't retry again if we remain in the same
page.