### PR TITLE
Fix odd hmdmc stuff

### DIFF
--- a/app/models/labware.rb
+++ b/app/models/labware.rb
@@ -85,16 +85,15 @@ class Labware < ApplicationRecord
     nil
   end
 
-  # Returns an array of all of the unique HMDMC values for the labware
-  def hmdmc_list
-    return nil if contents.nil?
-    hmdmc_list = Set.new()
+  # Returns a set of all of the unique HMDMC values for the labware
+  def hmdmc_set
+    hmdmcs = Set.new()
+    return hmdmcs if contents.nil?
     contents.each do |_k, v|
       h = material_is_human?(v) && v['hmdmc']
-      hmdmc_list.add(h) if h
+      hmdmcs.add(h) if h
     end
-    return hmdmc_list.to_a unless hmdmc_list.empty?
-    nil
+    hmdmcs
   end
 
   def confirmed_no_hmdmc?

--- a/app/models/material_submission.rb
+++ b/app/models/material_submission.rb
@@ -177,16 +177,14 @@ class MaterialSubmission < ApplicationRecord
     nil
   end
 
-  # Returns an array of all unique HMDMC numbers in the submission
-  def hmdmc_list
-    return nil if labwares.nil?
-    hmdmc_list = Set.new()
+  # Returns a set of all unique HMDMC numbers in the submission
+  def hmdmc_set
+    hmdmcs = Set.new()
+    return hmdmcs if labwares.nil?
     labwares.each do |lw|
-      h = lw.hmdmc_list
-      hmdmc_list.merge(h) if h
+      hmdmcs.merge(lw.hmdmc_set)
     end
-    return hmdmc_list.to_a unless hmdmc_list.empty?
-    nil
+    hmdmcs
   end
 
   # Get the total number of samples for this submission

--- a/lib/event_message.rb
+++ b/lib/event_message.rb
@@ -57,7 +57,7 @@ class EventMessage
       ],
       "metadata": {
         "submission_id": @submission.id,
-        "hmdmc_list": @submission.hmdmc_list,
+        "hmdmc": @submission.hmdmc_set.to_a,
         "confirmed_no_hmdmc": @submission.first_confirmed_no_hmdmc,
         "sample_custodian": @submission.contact.email,
         "total_samples": @submission.total_samples,

--- a/spec/lib/event_message_spec.rb
+++ b/spec/lib/event_message_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'set'
 
 RSpec.describe 'EventMessage' do
   describe '#initialize messages' do
@@ -22,7 +23,7 @@ RSpec.describe 'EventMessage' do
       submission = build(:material_submission, status: MaterialSubmission.ACTIVE)
 
       allow(SecureRandom).to receive(:uuid).and_return 'a_uuid'
-      allow(submission).to receive(:hmdmc_list).and_return '[12/000, 13/999]'
+      allow(submission).to receive(:hmdmc_set).and_return Set.new(['12/000', '13/999'])
       allow(submission).to receive(:total_samples).and_return 12
       allow(submission).to receive(:first_confirmed_no_hmdmc).and_return 'test@test.com'
 
@@ -39,7 +40,7 @@ RSpec.describe 'EventMessage' do
         expect(json['uuid']).to eq 'a_uuid'
         expect(json['timestamp']).to eq Time.now.utc.iso8601
         expect(json['user_identifier']).to eq submission.owner_email
-        expect(json['metadata']['hmdmc_list']).to eq '[12/000, 13/999]'
+        expect(json['metadata']['hmdmc']).to eq ['12/000', '13/999']
         expect(json['metadata']['sample_custodian']).to eq submission.contact.email
         expect(json['metadata']['total_samples']).to eq 12
         expect(json['metadata']['zipkin_trace_id']).to eq 'a_trace_id'


### PR DESCRIPTION
1. Use a set for 'all unique hmdmcs from ...' instead of converting
  back and forward to and from an array.
2. Don't return nil to mean an empty array (or set).
3. The metadata key for hmdmcs must be called "hmdmc",
  not "hmdmc_list".
4. The tests were mocking out hmdmc_list to return things that
  they would never possibly return, like the string "[12/000, 13/999]".