### PR TITLE
Fix table heading describing owner email as "Sanger Guardian email"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,5 +38,5 @@ en:
     attributes:
       manifest:
         id: 'Manifest Identifier'
-        email: 'Sample Guardian email'
-        contact: 'Internal Contact'
+        email: 'Owner'
+        contact: 'Sample Guardian email'


### PR DESCRIPTION
The table heading comes from en.yml, which listed "email: 'Sample Guardian email'".
But the table column actually contains the manifest owner email.
I changed the names in en.yml to reflect usage.