### PR TITLE
Render only one table

### DIFF
--- a/app/javascript/react/components/manifest_containers.jsx
+++ b/app/javascript/react/components/manifest_containers.jsx
@@ -148,13 +148,10 @@ const LabwareContent = connect((state, ownProps) => {
 
 const LabwareContentsComponent = (props) => {
   logName('LabwareContentsComponent')
+  const labwareIndex = props.labwareIndexes[props.selectedTabPosition]
   return (
     <div className="tab-content">
-      { props.labwareIndexes.map((labwareIndex, pos) => {
-        return (
-          <LabwareContent key={labwareIndex} labwareIndex={labwareIndex} position={pos} />
-        )
-      })}
+      <LabwareContent key={labwareIndex} labwareIndex={labwareIndex} position={labwareIndex} />
     </div>
   )
 }
@@ -162,6 +159,7 @@ const LabwareContentsComponent = (props) => {
 const LabwareContents = connect((state) => {
   logName('LabwareContents')
   return {
+    selectedTabPosition: StateSelectors.manifest.selectedTabPosition(state),
     labwareIndexes: StateSelectors.manifest.labwareIndexes(state)
   }
 })(LabwareContentsComponent)

--- a/spec/javascript/react/components/manifest_containers_spec.jsx
+++ b/spec/javascript/react/components/manifest_containers_spec.jsx
@@ -21,6 +21,7 @@ describe('<ManifestContainers />', () => {
       "taxonomy_service_url": ""
     },
     "manifest": {
+      "selectedTabPosition": "0",
       "manifest_id": "1234",
       "labwares": [
         {"supplier_plate_name": "Labware 1","positions": ["A:1","B:1"]},
@@ -120,23 +121,20 @@ describe('<ManifestContainers />', () => {
     })
 
     context('<LabwareContent>', () => {
-      it('displays the 2 labwares', () => {
-        expect(wrapper.find('LabwareContentComponent')).to.have.length(2)
+      it('displays just the labware selected', () => {
+        expect(wrapper.find('LabwareContentComponent')).to.have.length(1)
       })
     })
 
     context('<LabwareContentAddress>', () => {
-      it('displays 2 positions for the first labware', () => {
+      it('displays 2 positions', () => {
         expect(wrapper.find('LabwareContentComponent').first().find('LabwareContentAddressComponent')).to.have.length(2)
       })
-      it('displays 1 positions for the last labware', () => {
-        expect(wrapper.find('LabwareContentComponent').last().find('LabwareContentAddressComponent')).to.have.length(1)
-      })
-
-      it('displays all the addresses of the status', ()=> {
-        ["A:1","B:1","1"].forEach((val) => {
+      it('displays all the addresses', ()=> {
+        (["A:1","B:1"]).forEach((val) => {
           expect(wrapper.find('LabwareContentAddressComponent').filterWhere((n) => n.prop('address')==val)).to.have.length(1)
         })
+
       })
     })
 


### PR DESCRIPTION
If creating a big number of plates (10 for example), each labware was generating its own table even if it was not displayed making input edition very unresponsive. This patch removes the tables not shown from the rendering process.